### PR TITLE
Returned MSA optionally includes the depths and errors.

### DIFF
--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -66,7 +66,9 @@ public:
         uint32_t sequence_size, const std::vector<uint32_t>& weights);
 
     void generate_multiple_sequence_alignment(std::vector<std::string>& dst,
-        bool include_consensus = false);
+        bool include_consensus = false,
+        bool include_depths = false,
+        bool include_errors = false);
 
     std::string generate_consensus();
     // returns coverages


### PR DESCRIPTION
The depths and errors are returned as comma separated strings of values.  For
each base in the consensus sequence, the depth is the number of non-N and
non-deletion (i.e. not 'N' and not '-') bases that cover/align that cover the
consensus base across the non-consensus sequences.  For each base in the
consensus sequence, the number of errors are the bases from non-consensus
sequences (same as the depth calculation) that mismatch or differ from the
consensus sequence.

For example, consider a MSA with the following (consensus on the bottom):

```
CCAAAAAA-AAATTTCT
CCAAAAAA-AAATTTTT
--AAAAAACAAATTTTT
CCAAAAAA-AAATTTTT
```

The depths and errors would be
```
2,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3
0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0
```

Three things to note:
1. The first sequence has an error relative ot the consensus, and we see that
counted in the second to last value in the error string.
2. No depth is counted from the third sequence in the first two bases of the consensus.
3. There is no depth or error value for a deletion in the consensus (i.e. when
the consensus MSA string has a '-', in this case due to the third sequence
having an extra 'C').