### PR TITLE
Added serialisation support using cereal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/googletest"]
 	path = vendor/googletest
 	url = https://github.com/google/googletest
+[submodule "vendor/cereal"]
+	path = vendor/cereal
+	url = https://github.com/USCiLab/cereal.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/spoa DESTINATION ${CMAKE_I
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/spoa.pc.in ${CMAKE_CURRENT_BINARY_DIR}/spoa-1.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spoa-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+add_subdirectory(vendor/cereal EXCLUDE_FROM_ALL)
+include_directories(${PROJECT_SOURCE_DIR}/vendor/cereal/include)
+
 if (spoa_build_executable)
     add_executable(spoa_bin
         src/sequence.cpp
@@ -54,7 +57,7 @@ if (spoa_build_executable)
         add_subdirectory(vendor/bioparser EXCLUDE_FROM_ALL)
     endif()
 
-    target_link_libraries(spoa_bin spoa bioparser)
+    target_link_libraries(spoa_bin spoa bioparser cereal)
     set_target_properties(spoa_bin PROPERTIES OUTPUT_NAME spoa)
 
     install(TARGETS spoa_bin DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -78,5 +81,5 @@ if (spoa_build_tests)
         add_subdirectory(vendor/googletest/googletest EXCLUDE_FROM_ALL)
     endif()
 
-    target_link_libraries(spoa_test spoa bioparser gtest_main)
+    target_link_libraries(spoa_test spoa bioparser cereal gtest_main)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/spoa DESTINATION ${CMAKE_I
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/spoa.pc.in ${CMAKE_CURRENT_BINARY_DIR}/spoa-1.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spoa-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+set(JUST_INSTALL_CEREAL On)
 add_subdirectory(vendor/cereal EXCLUDE_FROM_ALL)
 include_directories(${PROJECT_SOURCE_DIR}/vendor/cereal/include)
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -9,9 +9,10 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <vector>
-#include <utility>
 #include <unordered_set>
+#include <utility>
+#include <vector>
+#include "spoa/serialize.h"
 
 namespace spoa {
 
@@ -27,59 +28,54 @@ class Graph {
 public:
     ~Graph();
 
-    const std::vector<std::unique_ptr<Node>>& nodes() const {
-        return nodes_;
+    const std::vector<std::unique_ptr<Node>>& nodes() const { return nodes_; }
+
+    const std::vector<std::uint32_t>& rank_to_node_id() const
+    {
+	return rank_to_node_id_;
     }
 
-    const std::vector<std::uint32_t>& rank_to_node_id() const {
-        return rank_to_node_id_;
-    }
+    std::uint32_t num_codes() const { return num_codes_; };
 
-    std::uint32_t num_codes() const {
-        return num_codes_;
-    };
+    std::uint8_t coder(std::uint8_t c) const { return coder_[c]; }
 
-    std::uint8_t coder(std::uint8_t c) const {
-        return coder_[c];
-    }
-
-    std::uint8_t decoder(std::uint8_t code) const {
-        return decoder_[code];
-    }
+    std::uint8_t decoder(std::uint8_t code) const { return decoder_[code]; }
 
     void add_alignment(const Alignment& alignment, const std::string& sequence,
-        std::uint32_t weight = 1);
+		       std::uint32_t weight = 1);
 
     void add_alignment(const Alignment& alignment, const char* sequence,
-        std::uint32_t sequence_size, std::uint32_t weight = 1);
+		       std::uint32_t sequence_size, std::uint32_t weight = 1);
 
     void add_alignment(const Alignment& alignment, const std::string& sequence,
-        const std::string& quality);
+		       const std::string& quality);
 
     void add_alignment(const Alignment& alignment, const char* sequence,
-        std::uint32_t sequence_size, const char* quality,
-        std::uint32_t quality_size);
+		       std::uint32_t sequence_size, const char* quality,
+		       std::uint32_t quality_size);
 
     void add_alignment(const Alignment& alignment, const std::string& sequence,
-        const std::vector<std::uint32_t>& weights);
+		       const std::vector<std::uint32_t>& weights);
 
     void add_alignment(const Alignment& alignment, const char* sequence,
-        std::uint32_t sequence_size, const std::vector<std::uint32_t>& weights);
+		       std::uint32_t sequence_size,
+		       const std::vector<std::uint32_t>& weights);
 
     void generate_multiple_sequence_alignment(std::vector<std::string>& dst,
-        bool include_consensus = false);
+					      bool include_consensus = false);
 
     std::string generate_consensus();
     // returns  base coverages or complete summary matrix if verbose equals true
     std::string generate_consensus(std::vector<std::uint32_t>& dst,
-        bool verbose = false);
+				   bool verbose = false);
 
-    std::unique_ptr<Graph> subgraph(std::uint32_t begin_node_id,
-        std::uint32_t end_node_id,
-        std::vector<std::int32_t>& subgraph_to_graph_mapping) const;
+    std::unique_ptr<Graph> subgraph(
+	std::uint32_t begin_node_id, std::uint32_t end_node_id,
+	std::vector<std::int32_t>& subgraph_to_graph_mapping) const;
 
-    void update_alignment(Alignment& alignment,
-        const std::vector<std::int32_t>& subgraph_to_graph_mapping) const;
+    void update_alignment(
+	Alignment& alignment,
+	const std::vector<std::int32_t>& subgraph_to_graph_mapping) const;
 
     void print_dot(const std::string& path) const;
 
@@ -87,24 +83,34 @@ public:
 
     friend std::unique_ptr<Graph> createGraph();
 
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+	archive(num_sequences_, num_codes_, coder_, decoder_, nodes_,
+		rank_to_node_id_, sequences_begin_nodes_ids_, consensus_);
+    }
+
 private:
     Graph();
     Graph(const Graph&) = delete;
     const Graph& operator=(const Graph&) = delete;
 
-    static std::unique_ptr<Node> createNode(std::uint32_t id, std::uint32_t code);
+    static std::unique_ptr<Node> createNode(std::uint32_t id,
+					    std::uint32_t code);
 
     static std::unique_ptr<Edge> createEdge(std::uint32_t begin_node_id,
-        std::uint32_t end_node_id, std::uint32_t label, std::uint32_t weight);
+					    std::uint32_t end_node_id,
+					    std::uint32_t label,
+					    std::uint32_t weight);
 
     std::uint32_t add_node(std::uint32_t code);
 
     void add_edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
-        std::uint32_t weight);
+		  std::uint32_t weight);
 
     std::int32_t add_sequence(const char* sequence,
-        const std::vector<std::uint32_t>& weights, std::uint32_t begin,
-        std::uint32_t end);
+			      const std::vector<std::uint32_t>& weights,
+			      std::uint32_t begin, std::uint32_t end);
 
     void topological_sort();
 
@@ -113,14 +119,15 @@ private:
     void traverse_heaviest_bundle();
 
     std::uint32_t branch_completion(std::vector<std::int64_t>& scores,
-        std::vector<std::int32_t>& predecessors,
-        std::uint32_t rank);
+				    std::vector<std::int32_t>& predecessors,
+				    std::uint32_t rank);
 
     void extract_subgraph_nodes(std::vector<bool>& dst,
-        std::uint32_t current_node_id, std::uint32_t end_node_id) const;
+				std::uint32_t current_node_id,
+				std::uint32_t end_node_id) const;
 
     std::uint32_t initialize_multiple_sequence_alignment(
-        std::vector<std::uint32_t>& dst) const;
+	std::vector<std::uint32_t>& dst) const;
 
     std::uint32_t num_sequences_;
     std::uint32_t num_codes_;
@@ -130,30 +137,29 @@ private:
     std::vector<std::uint32_t> rank_to_node_id_;
     std::vector<std::uint32_t> sequences_begin_nodes_ids_;
     std::vector<std::uint32_t> consensus_;
-};
+};  // namespace spoa
 
 class Node {
 public:
     ~Node();
 
-    std::uint32_t id() const {
-        return id_;
+    std::uint32_t id() const { return id_; }
+
+    std::uint32_t code() const { return code_; }
+
+    const std::vector<std::shared_ptr<Edge>>& in_edges() const
+    {
+	return in_edges_;
     }
 
-    std::uint32_t code() const {
-        return code_;
+    const std::vector<std::shared_ptr<Edge>>& out_edges() const
+    {
+	return out_edges_;
     }
 
-    const std::vector<std::shared_ptr<Edge>>& in_edges() const {
-        return in_edges_;
-    }
-
-    const std::vector<std::shared_ptr<Edge>>& out_edges() const {
-        return out_edges_;
-    }
-
-    const std::vector<std::uint32_t>& aligned_nodes_ids() const {
-        return aligned_nodes_ids_;
+    const std::vector<std::uint32_t>& aligned_nodes_ids() const
+    {
+	return aligned_nodes_ids_;
     }
 
     bool successor(std::uint32_t& dst, std::uint32_t label) const;
@@ -161,6 +167,12 @@ public:
     std::uint32_t coverage() const;
 
     friend Graph;
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+	archive(id_, code_, in_edges_, out_edges_, aligned_nodes_ids_);
+    }
 
 private:
     Node(std::uint32_t id, std::uint32_t code);
@@ -178,20 +190,22 @@ class Edge {
 public:
     ~Edge();
 
-    std::uint32_t begin_node_id() const {
-        return begin_node_id_;
-    }
+    std::uint32_t begin_node_id() const { return begin_node_id_; }
 
-    std::uint32_t end_node_id() const {
-        return end_node_id_;
-    }
+    std::uint32_t end_node_id() const { return end_node_id_; }
 
     friend Graph;
     friend Node;
 
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+	archive(begin_node_id_, end_node_id_, sequence_labels_, total_weight_);
+    }
+
 private:
     Edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
-        std::uint32_t label, std::uint32_t weight);
+	 std::uint32_t label, std::uint32_t weight);
     Edge(const Edge&) = delete;
     const Edge& operator=(const Edge&) = delete;
 
@@ -203,4 +217,4 @@ private:
     std::int64_t total_weight_;
 };
 
-}
+}  // namespace spoa

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -175,7 +175,7 @@ public:
 	archive(id_, code_, in_edges_, out_edges_, aligned_nodes_ids_);
     }
 
-    Node(){};
+    Node();
     Node(std::uint32_t id, std::uint32_t code);
 
 private:

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -177,11 +177,10 @@ public:
 
     Node(){};
     Node(std::uint32_t id, std::uint32_t code);
-
-private:
     Node(const Node&) = delete;
     const Node& operator=(const Node&) = delete;
 
+private:
     std::uint32_t id_;
     std::uint32_t code_;
     std::vector<std::shared_ptr<Edge>> in_edges_;

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -142,7 +142,7 @@ private:
 
 class Node {
 public:
-    ~Node();
+    ~Node(){};
 
     std::uint32_t id() const { return id_; }
 
@@ -177,10 +177,10 @@ public:
 
     Node(){};
     Node(std::uint32_t id, std::uint32_t code);
-    // Node(const Node&) = delete;
-    const Node& operator=(const Node&) = delete;
 
 private:
+    Node(const Node&) = delete;
+    const Node& operator=(const Node&) = delete;
     std::uint32_t id_;
     std::uint32_t code_;
     std::vector<std::shared_ptr<Edge>> in_edges_;

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -35,6 +35,8 @@ public:
 	return rank_to_node_id_;
     }
 
+    std::uint32_t total_weights() const;
+
     std::uint32_t num_codes() const { return num_codes_; };
     std::uint32_t num_nodes() const { return nodes_.size(); };
     std::uint32_t num_sequences() const { return num_sequences_; };
@@ -149,8 +151,6 @@ public:
     std::uint32_t id() const { return id_; }
 
     std::uint32_t code() const { return code_; }
-
-    std::uint32_t total_weights() const;
 
     const std::vector<std::shared_ptr<Edge>>& in_edges() const
     {

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -142,7 +142,7 @@ private:
 
 class Node {
 public:
-    ~Node(){};
+    ~Node();
 
     std::uint32_t id() const { return id_; }
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -177,7 +177,7 @@ public:
 
     Node(){};
     Node(std::uint32_t id, std::uint32_t code);
-    Node(const Node&) = delete;
+    // Node(const Node&) = delete;
     const Node& operator=(const Node&) = delete;
 
 private:

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -115,6 +115,8 @@ private:
 			      const std::vector<std::uint32_t>& weights,
 			      std::uint32_t begin, std::uint32_t end);
 
+    std::uint32_t total_weights() const;
+
     void topological_sort();
 
     bool is_topologically_sorted() const;
@@ -206,6 +208,8 @@ public:
     {
 	archive(begin_node_id_, end_node_id_, sequence_labels_, total_weight_);
     }
+
+    std::uint32_t total_weight() const { return total_weight_; }
 
     Edge()
 	: begin_node_id_(),

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -177,7 +177,7 @@ public:
 	archive(id_, code_, in_edges_, out_edges_, aligned_nodes_ids_);
     }
 
-    Node();
+    Node() : id_(), code_(), in_edges_(), out_edges_(), aligned_nodes_ids_(){};
     Node(std::uint32_t id, std::uint32_t code);
 
 private:
@@ -207,7 +207,12 @@ public:
 	archive(begin_node_id_, end_node_id_, sequence_labels_, total_weight_);
     }
 
-    Edge(){};
+    Edge()
+	: begin_node_id_(),
+	  end_node_id_(),
+	  sequence_labels_(),
+	  total_weight_(){};
+
     Edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
 	 std::uint32_t label, std::uint32_t weight);
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -175,6 +175,7 @@ public:
 	archive(id_, code_, in_edges_, out_edges_, aligned_nodes_ids_);
     }
 
+    Node(){};
     Node(std::uint32_t id, std::uint32_t code);
 
 private:
@@ -205,6 +206,7 @@ public:
 	archive(begin_node_id_, end_node_id_, sequence_labels_, total_weight_);
     }
 
+    Edge(){};
     Edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
 	 std::uint32_t label, std::uint32_t weight);
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -82,8 +82,6 @@ public:
     void clear();
 
     friend std::unique_ptr<Graph> createGraph();
-    friend cereal::BinaryOutputArchive;
-    friend cereal::BinaryInputArchive;
 
     template <class Archive>
     void serialize(Archive& archive)
@@ -92,8 +90,9 @@ public:
 		rank_to_node_id_, sequences_begin_nodes_ids_, consensus_);
     }
 
-private:
     Graph();
+
+private:
     Graph(const Graph&) = delete;
     const Graph& operator=(const Graph&) = delete;
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -115,8 +115,6 @@ private:
 			      const std::vector<std::uint32_t>& weights,
 			      std::uint32_t begin, std::uint32_t end);
 
-    std::uint32_t total_weights() const;
-
     void topological_sort();
 
     bool is_topologically_sorted() const;
@@ -151,6 +149,8 @@ public:
     std::uint32_t id() const { return id_; }
 
     std::uint32_t code() const { return code_; }
+
+    std::uint32_t total_weights() const;
 
     const std::vector<std::shared_ptr<Edge>>& in_edges() const
     {

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -175,8 +175,9 @@ public:
 	archive(id_, code_, in_edges_, out_edges_, aligned_nodes_ids_);
     }
 
-private:
     Node(std::uint32_t id, std::uint32_t code);
+
+private:
     Node(const Node&) = delete;
     const Node& operator=(const Node&) = delete;
 
@@ -204,9 +205,10 @@ public:
 	archive(begin_node_id_, end_node_id_, sequence_labels_, total_weight_);
     }
 
-private:
     Edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
 	 std::uint32_t label, std::uint32_t weight);
+
+private:
     Edge(const Edge&) = delete;
     const Edge& operator=(const Edge&) = delete;
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -82,6 +82,8 @@ public:
     void clear();
 
     friend std::unique_ptr<Graph> createGraph();
+    friend cereal::BinaryOutputArchive;
+    friend cereal::BinaryInputArchive;
 
     template <class Archive>
     void serialize(Archive& archive)

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -36,6 +36,8 @@ public:
     }
 
     std::uint32_t num_codes() const { return num_codes_; };
+    std::uint32_t num_nodes() const { return nodes_.size(); };
+    std::uint32_t num_sequences() const { return num_sequences_; };
 
     std::uint8_t coder(std::uint8_t c) const { return coder_[c]; }
 

--- a/include/spoa/serialize.h
+++ b/include/spoa/serialize.h
@@ -1,0 +1,13 @@
+#ifndef SERIALIZE_H_INCLUDED
+#define SERIALIZE_H_INCLUDED
+
+#define CEREAL_THREAD_SAFE 1
+#include <cereal/access.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/cereal.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/memory.hpp>
+#include <cereal/types/unordered_map.hpp>
+#include <cereal/types/vector.hpp>
+
+#endif

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -25,10 +25,6 @@ Node::Node(std::uint32_t id, std::uint32_t code)
 {
 }
 
-Node::Node() : id_(0), code_(0), in_edges_(), out_edges_(), aligned_nodes_ids_()
-{
-}
-
 Node::~Node() {}
 
 bool Node::successor(std::uint32_t& dst, std::uint32_t label) const

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -311,7 +311,7 @@ std::int32_t Graph::add_sequence(const char* sequence,
     return first_node_id;
 }
 
-std::uint32_t Graph::total_weights() const
+std::uint32_t Graph::total_weights()
 {
     std::uint32_t total_w = 0;
     for (auto& n : nodes_) {

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -311,6 +311,17 @@ std::int32_t Graph::add_sequence(const char* sequence,
     return first_node_id;
 }
 
+std::uint32_t Graph::total_weights() const
+{
+    std::uint32_t total_w = 0;
+    for (auto& n : nodes_) {
+	for (auto e : n->out_edges()) {
+	    total_w += e->total_weight();
+	}
+    }
+    return total_w;
+}
+
 void Graph::topological_sort()
 {
     rank_to_node_id_.clear();

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -311,7 +311,7 @@ std::int32_t Graph::add_sequence(const char* sequence,
     return first_node_id;
 }
 
-std::uint32_t Graph::total_weights()
+std::uint32_t Graph::total_weights() const
 {
     std::uint32_t total_w = 0;
     for (auto& n : nodes_) {

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -6,8 +6,8 @@
 
 #include <assert.h>
 #include <algorithm>
-#include <stack>
 #include <fstream>
+#include <stack>
 
 #include "spoa/graph.hpp"
 
@@ -15,253 +15,274 @@ namespace spoa {
 
 constexpr std::uint32_t kMaxAlphabetSize = 256;
 
-std::unique_ptr<Node> Graph::createNode(std::uint32_t id, std::uint32_t code) {
+std::unique_ptr<Node> Graph::createNode(std::uint32_t id, std::uint32_t code)
+{
     return std::unique_ptr<Node>(new Node(id, code));
 }
 
 Node::Node(std::uint32_t id, std::uint32_t code)
-        : id_(id), code_(code), in_edges_(), out_edges_(),
-        aligned_nodes_ids_() {
+    : id_(id), code_(code), in_edges_(), out_edges_(), aligned_nodes_ids_()
+{
 }
 
-Node::~Node() {
-}
+Node::~Node() {}
 
-bool Node::successor(std::uint32_t& dst, std::uint32_t label) const {
-
-    for (const auto& edge: out_edges_) {
-        for (const auto& l: edge->sequence_labels_) {
-            if (l == label) {
-                dst = edge->end_node_id_;
-                return true;
-            }
-        }
+bool Node::successor(std::uint32_t& dst, std::uint32_t label) const
+{
+    for (const auto& edge : out_edges_) {
+	for (const auto& l : edge->sequence_labels_) {
+	    if (l == label) {
+		dst = edge->end_node_id_;
+		return true;
+	    }
+	}
     }
     return false;
 }
 
-std::uint32_t Node::coverage() const {
-
+std::uint32_t Node::coverage() const
+{
     std::unordered_set<std::uint32_t> label_set;
-    for (const auto& edge: in_edges_) {
-        for (const auto& label: edge->sequence_labels_) {
-            label_set.insert(label);
-        }
+    for (const auto& edge : in_edges_) {
+	for (const auto& label : edge->sequence_labels_) {
+	    label_set.insert(label);
+	}
     }
-    for (const auto& edge: out_edges_) {
-        for (const auto& label: edge->sequence_labels_) {
-            label_set.insert(label);
-        }
+    for (const auto& edge : out_edges_) {
+	for (const auto& label : edge->sequence_labels_) {
+	    label_set.insert(label);
+	}
     }
     return label_set.size();
 }
 
 std::unique_ptr<Edge> Graph::createEdge(std::uint32_t begin_node_id,
-    std::uint32_t end_node_id, std::uint32_t label, std::uint32_t weight) {
-
-    return std::unique_ptr<Edge>(new Edge(begin_node_id, end_node_id, label,
-        weight));
+					std::uint32_t end_node_id,
+					std::uint32_t label,
+					std::uint32_t weight)
+{
+    return std::unique_ptr<Edge>(
+	new Edge(begin_node_id, end_node_id, label, weight));
 }
 
 Edge::Edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
-    std::uint32_t label, std::uint32_t weight)
-        : begin_node_id_(begin_node_id), end_node_id_(end_node_id),
-        sequence_labels_(1, label), total_weight_(weight) {
+	   std::uint32_t label, std::uint32_t weight)
+    : begin_node_id_(begin_node_id),
+      end_node_id_(end_node_id),
+      sequence_labels_(1, label),
+      total_weight_(weight)
+{
 }
 
-Edge::~Edge() {
-}
+Edge::~Edge() {}
 
-void Edge::add_sequence(std::uint32_t label, std::uint32_t weight) {
+void Edge::add_sequence(std::uint32_t label, std::uint32_t weight)
+{
     sequence_labels_.emplace_back(label);
     total_weight_ += weight;
 }
 
-std::unique_ptr<Graph> createGraph() {
+std::unique_ptr<Graph> createGraph()
+{
     return std::unique_ptr<Graph>(new Graph());
 }
 
 Graph::Graph()
-        : num_sequences_(0), num_codes_(0), coder_(kMaxAlphabetSize, -1),
-        decoder_(kMaxAlphabetSize, -1), nodes_(), rank_to_node_id_(),
-        sequences_begin_nodes_ids_(), consensus_() {
+    : num_sequences_(0),
+      num_codes_(0),
+      coder_(kMaxAlphabetSize, -1),
+      decoder_(kMaxAlphabetSize, -1),
+      nodes_(),
+      rank_to_node_id_(),
+      sequences_begin_nodes_ids_(),
+      consensus_()
+{
 }
 
-Graph::~Graph() {
-}
+Graph::~Graph() {}
 
-std::uint32_t Graph::add_node(std::uint32_t code) {
+std::uint32_t Graph::add_node(std::uint32_t code)
+{
     std::uint32_t node_id = nodes_.size();
     nodes_.emplace_back(createNode(node_id, code));
     return node_id;
 }
 
 void Graph::add_edge(std::uint32_t begin_node_id, std::uint32_t end_node_id,
-    std::uint32_t weight) {
-
+		     std::uint32_t weight)
+{
     assert(begin_node_id < nodes_.size() && end_node_id < nodes_.size());
 
-    for (const auto& edge: nodes_[begin_node_id]->out_edges_) {
-        if (edge->end_node_id_ == end_node_id) {
-            edge->add_sequence(num_sequences_, weight);
-            return;
-        }
+    for (const auto& edge : nodes_[begin_node_id]->out_edges_) {
+	if (edge->end_node_id_ == end_node_id) {
+	    edge->add_sequence(num_sequences_, weight);
+	    return;
+	}
     }
 
-    std::shared_ptr<Edge> edge = createEdge(begin_node_id, end_node_id,
-        num_sequences_, weight);
+    std::shared_ptr<Edge> edge =
+	createEdge(begin_node_id, end_node_id, num_sequences_, weight);
     nodes_[begin_node_id]->out_edges_.emplace_back(edge);
     nodes_[end_node_id]->in_edges_.emplace_back(edge);
 }
 
 void Graph::add_alignment(const Alignment& alignment,
-    const std::string& sequence, std::uint32_t weight) {
-
+			  const std::string& sequence, std::uint32_t weight)
+{
     add_alignment(alignment, sequence.c_str(), sequence.size(), weight);
 }
 
 void Graph::add_alignment(const Alignment& alignment, const char* sequence,
-    std::uint32_t sequence_size, std::uint32_t weight) {
-
+			  std::uint32_t sequence_size, std::uint32_t weight)
+{
     std::vector<std::uint32_t> weights(sequence_size, weight);
     add_alignment(alignment, sequence, sequence_size, weights);
 }
 
-void Graph::add_alignment(const Alignment& alignment, const std::string& sequence,
-    const std::string& quality) {
-
-    add_alignment(alignment, sequence.c_str(), sequence.size(),
-        quality.c_str(), quality.size());
+void Graph::add_alignment(const Alignment& alignment,
+			  const std::string& sequence,
+			  const std::string& quality)
+{
+    add_alignment(alignment, sequence.c_str(), sequence.size(), quality.c_str(),
+		  quality.size());
 }
 
 void Graph::add_alignment(const Alignment& alignment, const char* sequence,
-    std::uint32_t sequence_size, const char* quality,
-    std::uint32_t quality_size) {
-
+			  std::uint32_t sequence_size, const char* quality,
+			  std::uint32_t quality_size)
+{
     std::vector<std::uint32_t> weights;
     for (std::uint32_t i = 0; i < quality_size; ++i) {
-        weights.emplace_back(static_cast<std::uint32_t>(quality[i] - 33)); // PHRED quality
+	weights.emplace_back(
+	    static_cast<std::uint32_t>(quality[i] - 33));  // PHRED quality
     }
     add_alignment(alignment, sequence, sequence_size, weights);
 }
 
-void Graph::add_alignment(const Alignment& alignment, const std::string& sequence,
-    const std::vector<std::uint32_t>& weights) {
-
+void Graph::add_alignment(const Alignment& alignment,
+			  const std::string& sequence,
+			  const std::vector<std::uint32_t>& weights)
+{
     add_alignment(alignment, sequence.c_str(), sequence.size(), weights);
 }
 
 void Graph::add_alignment(const Alignment& alignment, const char* sequence,
-    std::uint32_t sequence_size, const std::vector<std::uint32_t>& weights) {
-
+			  std::uint32_t sequence_size,
+			  const std::vector<std::uint32_t>& weights)
+{
     if (sequence_size == 0) {
-        return;
+	return;
     }
     if (sequence_size != weights.size()) {
-        throw std::invalid_argument("[spoa::Graph::add_alignment] error: "
-            "sequence and weights are of unequal size!");
+	throw std::invalid_argument(
+	    "[spoa::Graph::add_alignment] error: "
+	    "sequence and weights are of unequal size!");
     }
 
     for (std::uint32_t i = 0; i < sequence_size; ++i) {
-        auto c = sequence[i];
-        if (coder_[c] == -1) {
-            coder_[c] = num_codes_;
-            decoder_[num_codes_] = c;
-            ++num_codes_;
-        }
+	auto c = sequence[i];
+	if (coder_[c] == -1) {
+	    coder_[c] = num_codes_;
+	    decoder_[num_codes_] = c;
+	    ++num_codes_;
+	}
     }
 
-    if (alignment.empty()) { // no alignment
-        std::int32_t begin_node_id = add_sequence(sequence, weights, 0,
-            sequence_size);
-        ++num_sequences_;
-        sequences_begin_nodes_ids_.emplace_back(begin_node_id);
+    if (alignment.empty()) {  // no alignment
+	std::int32_t begin_node_id =
+	    add_sequence(sequence, weights, 0, sequence_size);
+	++num_sequences_;
+	sequences_begin_nodes_ids_.emplace_back(begin_node_id);
 
-        topological_sort();
-        return;
+	topological_sort();
+	return;
     }
 
     std::vector<std::uint32_t> valid_seq_ids;
-    for (const auto& it: alignment) {
-        if (it.second != -1) {
-            valid_seq_ids.emplace_back(it.second);
-        }
+    for (const auto& it : alignment) {
+	if (it.second != -1) {
+	    valid_seq_ids.emplace_back(it.second);
+	}
     }
 
     assert(valid_seq_ids.front() <= sequence_size);
     assert(valid_seq_ids.back() + 1 <= sequence_size);
 
     std::uint32_t tmp = nodes_.size();
-    std::int32_t begin_node_id = add_sequence(sequence, weights, 0,
-        valid_seq_ids.front());
+    std::int32_t begin_node_id =
+	add_sequence(sequence, weights, 0, valid_seq_ids.front());
     std::int32_t head_node_id = tmp == nodes_.size() ? -1 : nodes_.size() - 1;
 
-    std::int32_t tail_node_id = add_sequence(sequence, weights,
-        valid_seq_ids.back() + 1, sequence_size);
+    std::int32_t tail_node_id = add_sequence(
+	sequence, weights, valid_seq_ids.back() + 1, sequence_size);
 
     std::int32_t new_node_id = -1;
-    float prev_weight = head_node_id == -1 ?
-        0 : weights[valid_seq_ids.front() - 1];
+    float prev_weight =
+	head_node_id == -1 ? 0 : weights[valid_seq_ids.front() - 1];
 
     for (std::uint32_t i = 0; i < alignment.size(); ++i) {
-        if (alignment[i].second == -1) {
-            continue;
-        }
+	if (alignment[i].second == -1) {
+	    continue;
+	}
 
-        char letter = sequence[alignment[i].second];
-        if (alignment[i].first == -1) {
-            new_node_id = add_node(coder_[letter]);
+	char letter = sequence[alignment[i].second];
+	if (alignment[i].first == -1) {
+	    new_node_id = add_node(coder_[letter]);
+	}
+	else {
+	    if (decoder_[nodes_[alignment[i].first]->code_] == letter) {
+		new_node_id = alignment[i].first;
+	    }
+	    else {
+		std::int32_t aligned_to_node_id = -1;
+		for (const auto& aid :
+		     nodes_[alignment[i].first]->aligned_nodes_ids_) {
+		    if (decoder_[nodes_[aid]->code_] == letter) {
+			aligned_to_node_id = aid;
+			break;
+		    }
+		}
 
-        } else {
-            if (decoder_[nodes_[alignment[i].first]->code_] == letter) {
-                new_node_id = alignment[i].first;
+		if (aligned_to_node_id == -1) {
+		    new_node_id = add_node(coder_[letter]);
 
-            } else {
-                std::int32_t aligned_to_node_id = -1;
-                for (const auto& aid: nodes_[alignment[i].first]->aligned_nodes_ids_) {
-                    if (decoder_[nodes_[aid]->code_] == letter) {
-                        aligned_to_node_id = aid;
-                        break;
-                    }
-                }
+		    for (const auto& aid :
+			 nodes_[alignment[i].first]->aligned_nodes_ids_) {
+			nodes_[new_node_id]->aligned_nodes_ids_.emplace_back(
+			    aid);
+			nodes_[aid]->aligned_nodes_ids_.emplace_back(
+			    new_node_id);
+		    }
 
-                if (aligned_to_node_id == -1) {
-                    new_node_id = add_node(coder_[letter]);
+		    nodes_[new_node_id]->aligned_nodes_ids_.emplace_back(
+			alignment[i].first);
+		    nodes_[alignment[i].first]->aligned_nodes_ids_.emplace_back(
+			new_node_id);
+		}
+		else {
+		    new_node_id = aligned_to_node_id;
+		}
+	    }
+	}
 
-                    for (const auto& aid: nodes_[alignment[i].first]->aligned_nodes_ids_) {
-                        nodes_[new_node_id]->aligned_nodes_ids_.emplace_back(aid);
-                        nodes_[aid]->aligned_nodes_ids_.emplace_back(new_node_id);
-                    }
+	if (begin_node_id == -1) {
+	    begin_node_id = new_node_id;
+	}
 
-                    nodes_[new_node_id]->aligned_nodes_ids_.emplace_back(
-                        alignment[i].first);
-                    nodes_[alignment[i].first]->aligned_nodes_ids_.emplace_back(
-                        new_node_id);
+	if (head_node_id != -1) {
+	    // both nodes contribute to edge weight
+	    add_edge(head_node_id, new_node_id,
+		     prev_weight + weights[alignment[i].second]);
+	}
 
-                } else {
-                    new_node_id = aligned_to_node_id;
-                }
-            }
-        }
-
-        if (begin_node_id == -1) {
-            begin_node_id = new_node_id;
-        }
-
-        if (head_node_id != -1) {
-            // both nodes contribute to edge weight
-            add_edge(head_node_id, new_node_id,
-                prev_weight + weights[alignment[i].second]);
-        }
-
-        head_node_id = new_node_id;
-        prev_weight = weights[alignment[i].second];
+	head_node_id = new_node_id;
+	prev_weight = weights[alignment[i].second];
     }
 
     if (tail_node_id != -1) {
-        // both nodes contribute to edge weight
-        add_edge(head_node_id, tail_node_id,
-            prev_weight + weights[valid_seq_ids.back() + 1]);
+	// both nodes contribute to edge weight
+	add_edge(head_node_id, tail_node_id,
+		 prev_weight + weights[valid_seq_ids.back() + 1]);
     }
 
     ++num_sequences_;
@@ -271,27 +292,27 @@ void Graph::add_alignment(const Alignment& alignment, const char* sequence,
 }
 
 std::int32_t Graph::add_sequence(const char* sequence,
-    const std::vector<std::uint32_t>& weights, std::uint32_t begin,
-    std::uint32_t end) {
-
+				 const std::vector<std::uint32_t>& weights,
+				 std::uint32_t begin, std::uint32_t end)
+{
     if (begin == end) {
-        return -1;
+	return -1;
     }
 
     std::int32_t first_node_id = add_node(coder_[sequence[begin]]);
 
     std::uint32_t node_id;
     for (std::uint32_t i = begin + 1; i < end; ++i) {
-        node_id = add_node(coder_[sequence[i]]);
-        // both nodes contribute to edge weight
-        add_edge(node_id - 1, node_id, weights[i - 1] + weights[i]);
+	node_id = add_node(coder_[sequence[i]]);
+	// both nodes contribute to edge weight
+	add_edge(node_id - 1, node_id, weights[i - 1] + weights[i]);
     }
 
     return first_node_id;
 }
 
-void Graph::topological_sort() {
-
+void Graph::topological_sort()
+{
     rank_to_node_id_.clear();
 
     // 0 - unmarked, 1 - temporarily marked, 2 - permanently marked
@@ -300,96 +321,101 @@ void Graph::topological_sort() {
     std::stack<std::uint32_t> nodes_to_visit;
 
     for (std::uint32_t i = 0; i < nodes_.size(); ++i) {
-        if (node_marks[i] != 0) {
-            continue;
-        }
+	if (node_marks[i] != 0) {
+	    continue;
+	}
 
-        nodes_to_visit.push(i);
-        while (nodes_to_visit.size() != 0) {
-            std::uint32_t node_id = nodes_to_visit.top();
-            bool valid = true;
+	nodes_to_visit.push(i);
+	while (nodes_to_visit.size() != 0) {
+	    std::uint32_t node_id = nodes_to_visit.top();
+	    bool valid = true;
 
-            if (node_marks[node_id] != 2) {
-                for (const auto& edge: nodes_[node_id]->in_edges_) {
-                    if (node_marks[edge->begin_node_id_] != 2) {
-                        nodes_to_visit.push(edge->begin_node_id_);
-                        valid = false;
-                    }
-                }
+	    if (node_marks[node_id] != 2) {
+		for (const auto& edge : nodes_[node_id]->in_edges_) {
+		    if (node_marks[edge->begin_node_id_] != 2) {
+			nodes_to_visit.push(edge->begin_node_id_);
+			valid = false;
+		    }
+		}
 
-                if (check_aligned_nodes[node_id]) {
-                    for (const auto& aid: nodes_[node_id]->aligned_nodes_ids_) {
-                        if (node_marks[aid] != 2) {
-                            nodes_to_visit.push(aid);
-                            check_aligned_nodes[aid] = false;
-                            valid = false;
-                        }
-                    }
-                }
+		if (check_aligned_nodes[node_id]) {
+		    for (const auto& aid :
+			 nodes_[node_id]->aligned_nodes_ids_) {
+			if (node_marks[aid] != 2) {
+			    nodes_to_visit.push(aid);
+			    check_aligned_nodes[aid] = false;
+			    valid = false;
+			}
+		    }
+		}
 
-                assert((valid || node_marks[node_id] != 1) &&
-                    "Graph is not a DAG!");
+		assert((valid || node_marks[node_id] != 1) &&
+		       "Graph is not a DAG!");
 
-                if (valid) {
-                    node_marks[node_id] = 2;
-                    if (check_aligned_nodes[node_id]) {
-                        rank_to_node_id_.push_back(node_id);
-                        for (const auto& aid: nodes_[node_id]->aligned_nodes_ids_) {
-                            rank_to_node_id_.emplace_back(aid);
-                        }
-                    }
-                } else {
-                    node_marks[node_id] = 1;
-                }
-            }
+		if (valid) {
+		    node_marks[node_id] = 2;
+		    if (check_aligned_nodes[node_id]) {
+			rank_to_node_id_.push_back(node_id);
+			for (const auto& aid :
+			     nodes_[node_id]->aligned_nodes_ids_) {
+			    rank_to_node_id_.emplace_back(aid);
+			}
+		    }
+		}
+		else {
+		    node_marks[node_id] = 1;
+		}
+	    }
 
-            if (valid) {
-                nodes_to_visit.pop();
-            }
-        }
+	    if (valid) {
+		nodes_to_visit.pop();
+	    }
+	}
     }
 
     assert(is_topologically_sorted() == true);
 }
 
-bool Graph::is_topologically_sorted() const {
+bool Graph::is_topologically_sorted() const
+{
     assert(nodes_.size() == rank_to_node_id_.size());
 
     std::vector<bool> visited_nodes(nodes_.size(), false);
-    for (std::uint32_t node_id: rank_to_node_id_) {
-        for (const auto& edge: nodes_[node_id]->in_edges_) {
-            if (visited_nodes[edge->begin_node_id_] == false) {
-                return false;
-            }
-        }
-        visited_nodes[node_id] = true;
+    for (std::uint32_t node_id : rank_to_node_id_) {
+	for (const auto& edge : nodes_[node_id]->in_edges_) {
+	    if (visited_nodes[edge->begin_node_id_] == false) {
+		return false;
+	    }
+	}
+	visited_nodes[node_id] = true;
     }
 
     return true;
 }
 
 std::uint32_t Graph::initialize_multiple_sequence_alignment(
-    std::vector<std::uint32_t>& dst) const {
-
+    std::vector<std::uint32_t>& dst) const
+{
     dst.resize(nodes_.size(), 0);
 
     std::uint32_t msa_id = 0;
     for (std::uint32_t i = 0; i < nodes_.size(); ++i) {
-        std::uint32_t node_id = rank_to_node_id_[i];
+	std::uint32_t node_id = rank_to_node_id_[i];
 
-        dst[node_id] = msa_id;
-        for (std::uint32_t j = 0; j < nodes_[node_id]->aligned_nodes_ids_.size(); ++j) {
-            dst[rank_to_node_id_[++i]] = msa_id;
-        }
-        ++msa_id;
+	dst[node_id] = msa_id;
+	for (std::uint32_t j = 0;
+	     j < nodes_[node_id]->aligned_nodes_ids_.size(); ++j) {
+	    dst[rank_to_node_id_[++i]] = msa_id;
+	}
+	++msa_id;
     }
 
     return msa_id;
 }
 
 void Graph::generate_multiple_sequence_alignment(std::vector<std::string>& dst,
-    bool include_consensus) {
-
+						 bool include_consensus)
+{
     // assign msa id to each node
     std::vector<std::uint32_t> node_id_to_msa_id;
     auto msa_length = initialize_multiple_sequence_alignment(node_id_to_msa_id);
@@ -397,143 +423,147 @@ void Graph::generate_multiple_sequence_alignment(std::vector<std::string>& dst,
     // extract sequences from graph and create msa strings (add indels(-) where
     // necessary)
     for (std::uint32_t i = 0; i < num_sequences_; ++i) {
-        std::string alignment_str(msa_length, '-');
-        std::uint32_t node_id = sequences_begin_nodes_ids_[i];
+	std::string alignment_str(msa_length, '-');
+	std::uint32_t node_id = sequences_begin_nodes_ids_[i];
 
-        while (true) {
-            alignment_str[node_id_to_msa_id[node_id]] =
-                decoder_[nodes_[node_id]->code_];
+	while (true) {
+	    alignment_str[node_id_to_msa_id[node_id]] =
+		decoder_[nodes_[node_id]->code_];
 
-            if (!nodes_[node_id]->successor(node_id, i)) {
-                break;
-            }
-        }
+	    if (!nodes_[node_id]->successor(node_id, i)) {
+		break;
+	    }
+	}
 
-        dst.emplace_back(alignment_str);
+	dst.emplace_back(alignment_str);
     }
 
     if (include_consensus) {
-        // do the same for consensus sequence
-        traverse_heaviest_bundle();
+	// do the same for consensus sequence
+	traverse_heaviest_bundle();
 
-        std::string alignment_str(msa_length, '-');
-        for (const auto& node_id: consensus_) {
-            alignment_str[node_id_to_msa_id[node_id]] =
-                decoder_[nodes_[node_id]->code_];
-        }
-        dst.emplace_back(alignment_str);
+	std::string alignment_str(msa_length, '-');
+	for (const auto& node_id : consensus_) {
+	    alignment_str[node_id_to_msa_id[node_id]] =
+		decoder_[nodes_[node_id]->code_];
+	}
+	dst.emplace_back(alignment_str);
     }
 }
 
-std::string Graph::generate_consensus() {
-
+std::string Graph::generate_consensus()
+{
     traverse_heaviest_bundle();
     std::string consensus_str = "";
-    for (const auto& node_id: consensus_) {
-        consensus_str += decoder_[nodes_[node_id]->code_];
+    for (const auto& node_id : consensus_) {
+	consensus_str += decoder_[nodes_[node_id]->code_];
     }
 
     return consensus_str;
 }
 
 std::string Graph::generate_consensus(std::vector<std::uint32_t>& dst,
-    bool verbose) {
-
+				      bool verbose)
+{
     auto consensus_str = generate_consensus();
 
     dst.clear();
     if (verbose == false) {
-        for (const auto& node_id: consensus_) {
-            std::uint32_t total_coverage = nodes_[node_id]->coverage();
-            for (const auto& aid: nodes_[node_id]->aligned_nodes_ids_) {
-                total_coverage += nodes_[aid]->coverage();
-            }
-            dst.emplace_back(total_coverage);
-        }
-    } else {
-        dst.resize((num_codes_ + 1) * consensus_.size(), 0);
+	for (const auto& node_id : consensus_) {
+	    std::uint32_t total_coverage = nodes_[node_id]->coverage();
+	    for (const auto& aid : nodes_[node_id]->aligned_nodes_ids_) {
+		total_coverage += nodes_[aid]->coverage();
+	    }
+	    dst.emplace_back(total_coverage);
+	}
+    }
+    else {
+	dst.resize((num_codes_ + 1) * consensus_.size(), 0);
 
-        std::vector<std::uint32_t> node_id_to_msa_id;
-        initialize_multiple_sequence_alignment(node_id_to_msa_id);
+	std::vector<std::uint32_t> node_id_to_msa_id;
+	initialize_multiple_sequence_alignment(node_id_to_msa_id);
 
-        for (std::uint32_t i = 0; i < num_sequences_; ++i) {
-            auto node_id = sequences_begin_nodes_ids_[i];
+	for (std::uint32_t i = 0; i < num_sequences_; ++i) {
+	    auto node_id = sequences_begin_nodes_ids_[i];
 
-            bool count_indels = false;
-            std::uint32_t c = 0, l;
-            while (true) {
-                for (; c < consensus_.size() &&
-                    node_id_to_msa_id[consensus_[c]] < node_id_to_msa_id[node_id]; ++c);
-                if (c >= consensus_.size()) {
-                    break;
-                }
+	    bool count_indels = false;
+	    std::uint32_t c = 0, l;
+	    while (true) {
+		for (;
+		     c < consensus_.size() && node_id_to_msa_id[consensus_[c]] <
+						  node_id_to_msa_id[node_id];
+		     ++c)
+		    ;
+		if (c >= consensus_.size()) {
+		    break;
+		}
 
-                if (node_id_to_msa_id[consensus_[c]] == node_id_to_msa_id[node_id]) {
-                    if (count_indels) {
-                        for (std::uint32_t j = l + 1; j < c; ++j) {
-                            ++dst[num_codes_ * consensus_.size() + j];
-                        }
-                    }
-                    count_indels = true;
-                    l = c;
+		if (node_id_to_msa_id[consensus_[c]] ==
+		    node_id_to_msa_id[node_id]) {
+		    if (count_indels) {
+			for (std::uint32_t j = l + 1; j < c; ++j) {
+			    ++dst[num_codes_ * consensus_.size() + j];
+			}
+		    }
+		    count_indels = true;
+		    l = c;
 
-                    ++dst[nodes_[node_id]->code_ * consensus_.size() + c];
-                }
+		    ++dst[nodes_[node_id]->code_ * consensus_.size() + c];
+		}
 
-                if (!nodes_[node_id]->successor(node_id, i)) {
-                    break;
-                }
-            }
-        }
+		if (!nodes_[node_id]->successor(node_id, i)) {
+		    break;
+		}
+	    }
+	}
     }
 
     return consensus_str;
 }
 
-void Graph::traverse_heaviest_bundle() {
-
+void Graph::traverse_heaviest_bundle()
+{
     std::vector<std::int32_t> predecessors(nodes_.size(), -1);
     std::vector<std::int64_t> scores(nodes_.size(), -1);
 
     std::uint32_t max_score_id = 0;
-    for (const auto& node_id: rank_to_node_id_) {
-        for (const auto& edge: nodes_[node_id]->in_edges_) {
-            if (scores[node_id] < edge->total_weight_ ||
-                (scores[node_id] == edge->total_weight_ &&
-                scores[predecessors[node_id]] <= scores[edge->begin_node_id_])) {
+    for (const auto& node_id : rank_to_node_id_) {
+	for (const auto& edge : nodes_[node_id]->in_edges_) {
+	    if (scores[node_id] < edge->total_weight_ ||
+		(scores[node_id] == edge->total_weight_ &&
+		 scores[predecessors[node_id]] <=
+		     scores[edge->begin_node_id_])) {
+		scores[node_id] = edge->total_weight_;
+		predecessors[node_id] = edge->begin_node_id_;
+	    }
+	}
 
-                scores[node_id] = edge->total_weight_;
-                predecessors[node_id] = edge->begin_node_id_;
-            }
-        }
+	if (predecessors[node_id] != -1) {
+	    scores[node_id] += scores[predecessors[node_id]];
+	}
 
-        if (predecessors[node_id] != -1) {
-            scores[node_id] += scores[predecessors[node_id]];
-        }
-
-        if (scores[max_score_id] < scores[node_id]) {
-            max_score_id = node_id;
-        }
+	if (scores[max_score_id] < scores[node_id]) {
+	    max_score_id = node_id;
+	}
     }
 
     if (nodes_[max_score_id]->out_edges_.size() != 0) {
+	std::vector<std::uint32_t> node_id_to_rank(nodes_.size(), 0);
+	for (std::uint32_t i = 0; i < nodes_.size(); ++i) {
+	    node_id_to_rank[rank_to_node_id_[i]] = i;
+	}
 
-        std::vector<std::uint32_t> node_id_to_rank(nodes_.size(), 0);
-        for (std::uint32_t i = 0; i < nodes_.size(); ++i) {
-            node_id_to_rank[rank_to_node_id_[i]] = i;
-        }
-
-        while (nodes_[max_score_id]->out_edges_.size() != 0) {
-            max_score_id = branch_completion(scores, predecessors,
-                node_id_to_rank[max_score_id]);
-        }
+	while (nodes_[max_score_id]->out_edges_.size() != 0) {
+	    max_score_id = branch_completion(scores, predecessors,
+					     node_id_to_rank[max_score_id]);
+	}
     }
 
     // traceback
     consensus_.clear();
     while (predecessors[max_score_id] != -1) {
-        consensus_.emplace_back(max_score_id);
-        max_score_id = predecessors[max_score_id];
+	consensus_.emplace_back(max_score_id);
+	max_score_id = predecessors[max_score_id];
     }
     consensus_.emplace_back(max_score_id);
 
@@ -541,47 +571,47 @@ void Graph::traverse_heaviest_bundle() {
 }
 
 std::uint32_t Graph::branch_completion(std::vector<std::int64_t>& scores,
-    std::vector<std::int32_t>& predecessors, std::uint32_t rank) {
-
+				       std::vector<std::int32_t>& predecessors,
+				       std::uint32_t rank)
+{
     std::uint32_t node_id = rank_to_node_id_[rank];
-    for (const auto& edge: nodes_[node_id]->out_edges_) {
-        for (const auto& o_edge: nodes_[edge->end_node_id_]->in_edges_) {
-            if (o_edge->begin_node_id_ != node_id) {
-                scores[o_edge->begin_node_id_] = -1;
-            }
-        }
+    for (const auto& edge : nodes_[node_id]->out_edges_) {
+	for (const auto& o_edge : nodes_[edge->end_node_id_]->in_edges_) {
+	    if (o_edge->begin_node_id_ != node_id) {
+		scores[o_edge->begin_node_id_] = -1;
+	    }
+	}
     }
 
     std::int64_t max_score = 0;
     std::uint32_t max_score_id = 0;
     for (std::uint32_t i = rank + 1; i < rank_to_node_id_.size(); ++i) {
+	std::uint32_t node_id = rank_to_node_id_[i];
+	scores[node_id] = -1;
+	predecessors[node_id] = -1;
 
-        std::uint32_t node_id = rank_to_node_id_[i];
-        scores[node_id] = -1;
-        predecessors[node_id] = -1;
+	for (const auto& edge : nodes_[node_id]->in_edges_) {
+	    if (scores[edge->begin_node_id_] == -1) {
+		continue;
+	    }
 
-        for (const auto& edge: nodes_[node_id]->in_edges_) {
-            if (scores[edge->begin_node_id_] == -1) {
-                continue;
-            }
+	    if (scores[node_id] < edge->total_weight_ ||
+		(scores[node_id] == edge->total_weight_ &&
+		 scores[predecessors[node_id]] <=
+		     scores[edge->begin_node_id_])) {
+		scores[node_id] = edge->total_weight_;
+		predecessors[node_id] = edge->begin_node_id_;
+	    }
+	}
 
-            if (scores[node_id] < edge->total_weight_ ||
-                (scores[node_id] == edge->total_weight_ &&
-                scores[predecessors[node_id]] <= scores[edge->begin_node_id_])) {
+	if (predecessors[node_id] != -1) {
+	    scores[node_id] += scores[predecessors[node_id]];
+	}
 
-                scores[node_id] = edge->total_weight_;
-                predecessors[node_id] = edge->begin_node_id_;
-            }
-        }
-
-        if (predecessors[node_id] != -1) {
-            scores[node_id] += scores[predecessors[node_id]];
-        }
-
-        if (max_score < scores[node_id]) {
-            max_score = scores[node_id];
-            max_score_id = node_id;
-        }
+	if (max_score < scores[node_id]) {
+	    max_score = scores[node_id];
+	    max_score_id = node_id;
+	}
     }
 
     return max_score_id;
@@ -589,34 +619,35 @@ std::uint32_t Graph::branch_completion(std::vector<std::int64_t>& scores,
 
 // backtracing from right to left!
 void Graph::extract_subgraph_nodes(std::vector<bool>& dst,
-    std::uint32_t begin_node_id, std::uint32_t end_node_id) const {
-
+				   std::uint32_t begin_node_id,
+				   std::uint32_t end_node_id) const
+{
     dst.resize(nodes_.size(), false);
 
     std::stack<std::uint32_t> nodes_to_visit;
     nodes_to_visit.push(begin_node_id);
 
     while (nodes_to_visit.size() != 0) {
-        std::uint32_t node_id = nodes_to_visit.top();
-        nodes_to_visit.pop();
+	std::uint32_t node_id = nodes_to_visit.top();
+	nodes_to_visit.pop();
 
-        if (dst[node_id] == false && node_id >= end_node_id) {
-            for (const auto& edge: nodes_[node_id]->in_edges_) {
-                nodes_to_visit.push(edge->begin_node_id_);
-            }
-            for (const auto& aid: nodes_[node_id]->aligned_nodes_ids_) {
-                nodes_to_visit.push(aid);
-            }
+	if (dst[node_id] == false && node_id >= end_node_id) {
+	    for (const auto& edge : nodes_[node_id]->in_edges_) {
+		nodes_to_visit.push(edge->begin_node_id_);
+	    }
+	    for (const auto& aid : nodes_[node_id]->aligned_nodes_ids_) {
+		nodes_to_visit.push(aid);
+	    }
 
-            dst[node_id] = true;
-        }
+	    dst[node_id] = true;
+	}
     }
 }
 
-std::unique_ptr<Graph> Graph::subgraph(std::uint32_t begin_node_id,
-    std::uint32_t end_node_id,
-    std::vector<std::int32_t>& subgraph_to_graph_mapping) const {
-
+std::unique_ptr<Graph> Graph::subgraph(
+    std::uint32_t begin_node_id, std::uint32_t end_node_id,
+    std::vector<std::int32_t>& subgraph_to_graph_mapping) const
+{
     std::vector<bool> is_subgraph_node;
     extract_subgraph_nodes(is_subgraph_node, end_node_id, begin_node_id);
 
@@ -633,37 +664,37 @@ std::unique_ptr<Graph> Graph::subgraph(std::uint32_t begin_node_id,
     std::vector<std::int32_t> graph_to_subgraph_mapping(nodes_.size(), -1);
 
     for (std::uint32_t i = 0; i < is_subgraph_node.size(); ++i) {
-        if (is_subgraph_node[i] == false) {
-            continue;
-        }
+	if (is_subgraph_node[i] == false) {
+	    continue;
+	}
 
-        std::uint32_t subgraph_id = subgraph->add_node(nodes_[i]->code_);
-        graph_to_subgraph_mapping[i] = subgraph_id;
-        subgraph_to_graph_mapping[subgraph_id] = i;
+	std::uint32_t subgraph_id = subgraph->add_node(nodes_[i]->code_);
+	graph_to_subgraph_mapping[i] = subgraph_id;
+	subgraph_to_graph_mapping[subgraph_id] = i;
     }
 
     // add edges and aligned nodes
     for (std::uint32_t i = 0; i < is_subgraph_node.size(); ++i) {
-        if (is_subgraph_node[i] == false) {
-            continue;
-        }
+	if (is_subgraph_node[i] == false) {
+	    continue;
+	}
 
-        std::uint32_t subgraph_id = graph_to_subgraph_mapping[i];
+	std::uint32_t subgraph_id = graph_to_subgraph_mapping[i];
 
-        for (const auto& edge: nodes_[i]->in_edges_) {
-            if (graph_to_subgraph_mapping[edge->begin_node_id_] == -1) {
-                continue;
-            }
-            subgraph->add_edge(graph_to_subgraph_mapping[edge->begin_node_id_],
-                subgraph_id, edge->total_weight_);
-        }
-        for (const auto& aid: nodes_[i]->aligned_nodes_ids_) {
-            if (graph_to_subgraph_mapping[aid] == -1) {
-                continue;
-            }
-            subgraph->nodes_[subgraph_id]->aligned_nodes_ids_.emplace_back(
-                graph_to_subgraph_mapping[aid]);
-        }
+	for (const auto& edge : nodes_[i]->in_edges_) {
+	    if (graph_to_subgraph_mapping[edge->begin_node_id_] == -1) {
+		continue;
+	    }
+	    subgraph->add_edge(graph_to_subgraph_mapping[edge->begin_node_id_],
+			       subgraph_id, edge->total_weight_);
+	}
+	for (const auto& aid : nodes_[i]->aligned_nodes_ids_) {
+	    if (graph_to_subgraph_mapping[aid] == -1) {
+		continue;
+	    }
+	    subgraph->nodes_[subgraph_id]->aligned_nodes_ids_.emplace_back(
+		graph_to_subgraph_mapping[aid]);
+	}
     }
 
     subgraph->topological_sort();
@@ -671,61 +702,63 @@ std::unique_ptr<Graph> Graph::subgraph(std::uint32_t begin_node_id,
     return subgraph;
 }
 
-void Graph::update_alignment(Alignment& alignment,
-    const std::vector<std::int32_t>& subgraph_to_graph_mapping) const {
-
+void Graph::update_alignment(
+    Alignment& alignment,
+    const std::vector<std::int32_t>& subgraph_to_graph_mapping) const
+{
     for (std::uint32_t i = 0; i < alignment.size(); ++i) {
-        if (alignment[i].first != -1) {
-            alignment[i].first = subgraph_to_graph_mapping[alignment[i].first];
-        }
+	if (alignment[i].first != -1) {
+	    alignment[i].first = subgraph_to_graph_mapping[alignment[i].first];
+	}
     }
 }
 
-void Graph::print_dot(const std::string& path) const {
-
+void Graph::print_dot(const std::string& path) const
+{
     if (path.empty()) {
-        return;
+	return;
     }
 
     std::ofstream out(path);
 
     std::vector<std::int32_t> in_consensus(nodes_.size(), -1);
     std::int32_t rank = 0;
-    for (const auto& id: consensus_) {
-        in_consensus[id] = rank++;
+    for (const auto& id : consensus_) {
+	in_consensus[id] = rank++;
     }
 
     out << "digraph " << num_sequences_ << " {" << std::endl;
     out << "    graph [rankdir=LR]" << std::endl;
     for (std::uint32_t i = 0; i < nodes_.size(); ++i) {
-        out << "    " << i << " [label = \"" << i << " - ";
-        out << static_cast<char>(decoder_[nodes_[i]->code_]) << "\"";
-        if (in_consensus[i] != -1) {
-            out << ", style=filled, fillcolor=goldenrod1";
-        }
-        out << "]" << std::endl;
+	out << "    " << i << " [label = \"" << i << " - ";
+	out << static_cast<char>(decoder_[nodes_[i]->code_]) << "\"";
+	if (in_consensus[i] != -1) {
+	    out << ", style=filled, fillcolor=goldenrod1";
+	}
+	out << "]" << std::endl;
 
-        for (const auto& edge: nodes_[i]->out_edges_) {
-            out << "    " << i << " -> " << edge->end_node_id_;
-            out << " [label = \"" << edge->total_weight_ << "\"";
-            if (in_consensus[i] + 1 == in_consensus[edge->end_node_id_]) {
-                out << ", color=goldenrod1";
-            }
-            out << "]" << std::endl;
-        }
-        for (const auto& aid: nodes_[i]->aligned_nodes_ids_) {
-            if (aid > i) {
-                out << "    " << i << " -> " << aid;
-                out << " [style = dotted, arrowhead = none]" << std::endl;
-            }
-        }
+	for (const auto& edge : nodes_[i]->out_edges_) {
+	    out << "    " << i << " -> " << edge->end_node_id_;
+	    out << " [label = \"" << edge->total_weight_ << "\"";
+	    if (in_consensus[i] + 1 == in_consensus[edge->end_node_id_]) {
+		out << ", color=goldenrod1";
+	    }
+	    out << "]" << std::endl;
+	}
+	for (const auto& aid : nodes_[i]->aligned_nodes_ids_) {
+	    if (aid > i) {
+		out << "    " << i << " -> " << aid;
+		out << " [style = dotted, arrowhead = none]" << std::endl;
+	    }
+	}
     }
     out << "}" << std::endl;
 
     out.close();
 }
 
-void Graph::clear() {
+void Graph::clear()
+{
     std::fill(coder_.begin(), coder_.end(), -1);
     std::fill(decoder_.begin(), decoder_.end(), -1);
     nodes_.clear();
@@ -734,4 +767,4 @@ void Graph::clear() {
     consensus_.clear();
 }
 
-}
+}  // namespace spoa

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -25,6 +25,10 @@ Node::Node(std::uint32_t id, std::uint32_t code)
 {
 }
 
+Node::Node() : id_(0), code_(0), in_edges_(), out_edges_(), aligned_nodes_ids_()
+{
+}
+
 Node::~Node() {}
 
 bool Node::successor(std::uint32_t& dst, std::uint32_t label) const


### PR DESCRIPTION
Hello!

For one of my projects, I needed a way to efficiently serialize to disk the graphs constructed by spoa.
These modifications achieve that using the [cereal](https://uscilab.github.io/cereal/) library which I have found very practical to use.
To comply with the requirements of cereal, I had to add some default constructors and make some existing ones public. I have also added a couple of utility methods.
I am not very well versed in cmake, so the way I pull in cereal might not be the best.
Would you consider merging these additions into master (maybe after a bit of polishing). The amount of code I have added is pretty minimal.

Best,
Botond