### PR TITLE
Fix getopt handling on architectures where char is unsigned

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
 
     std::string dot_path = "";
 
-    char opt;
+    int opt;
     while ((opt = getopt_long(argc, argv, "m:n:g:e:q:c:l:r:d:h", options, nullptr)) != -1) {
         switch (opt) {
             case 'm': m = atoi(optarg); break;


### PR DESCRIPTION
gcc says:

```
src/main.cpp: In function ‘int main(int, char**)’:
src/main.cpp:41:85: warning: comparison is always true due to limited range of data type [-Wtype-limits]
   41 |     while ((opt = getopt_long(argc, argv, "m:n:g:e:q:c:l:r:d:h", options, nullptr)) != -1) {
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```