### PR TITLE
src/alignment_engine.cpp: support gcc-10

### DIFF
--- a/src/alignment_engine.cpp
+++ b/src/alignment_engine.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <algorithm>
 #include <exception>
+#include <stdexcept>
 
 #include "sisd_alignment_engine.hpp"
 #include "simd_alignment_engine.hpp"


### PR DESCRIPTION
Greetings,

This patch adds support for building _spoa_ with [Gcc 10](https://gcc.gnu.org/gcc-10/porting_to.html) by explicitely introducing the now missing _stdexcept_ header.  It fixes the following build error, reported initially under [Debian bug #957836](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=957836):
```
[...]
/<<PKGBUILDDIR>>/src/alignment_engine.cpp:41:20: error: ‘invalid_argument’ is not a member of ‘std’
   41 |         throw std::invalid_argument("[spoa::createAlignmentEngine] error: "
      |                    ^~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/alignment_engine.cpp:45:20: error: ‘invalid_argument’ is not a member of ‘std’
   45 |         throw std::invalid_argument("[spoa::createAlignmentEngine] error: "
      |                    ^~~~~~~~~~~~~~~~
```

I hope this helps,
Kind Regards.