### PR TITLE
Introduced SIMDe for portable SIMD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/googletest"]
 	path = vendor/googletest
 	url = https://github.com/google/googletest
+[submodule "vendor/simde"]
+	path = vendor/simde
+	url = https://github.com/nemequ/simde.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,25 @@ option(spoa_build_executable "Build spoa standalone tool" OFF)
 option(spoa_build_tests "Build spoa unit tests" OFF)
 option(spoa_optimize_for_native "Build spoa with -march=native" ON)
 option(spoa_optimize_for_portability "Build spoa with -msse4.1" OFF)
+option(spoa_use_simde "Use SIMDe library for porting vectorized code" OFF)
+option(spoa_use_simde_nonvec "Use SIMDe library for nonvectorized code" OFF)
+option(spoa_use_simde_openmp "Use SIMDe support for OpenMP SIMD" OFF)
 
 if (spoa_optimize_for_portability)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
 elseif (spoa_optimize_for_native)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
+
+if (spoa_use_simde OR spoa_use_simde_nonvec OR spoa_use_simde_openmp)
+    add_definitions(-DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES)
+    if (spoa_use_simde_nonvec)
+        add_definitions(-DSIMDE_NO_NATIVE)
+    endif()
+    if (spoa_use_simde_openmp)
+        add_definitions(-DSIMDE_ENABLE_OPENMP)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp-simd")
+    endif()
 endif()
 
 # build SPOA as a static library by default
@@ -34,7 +48,8 @@ add_library(spoa
 
 target_include_directories(spoa PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/simde>)
 
 set_target_properties(spoa
     PROPERTIES

--- a/src/simd_alignment_engine.cpp
+++ b/src/simd_alignment_engine.cpp
@@ -9,7 +9,17 @@
 #include <limits>
 
 extern "C" {
+    #ifdef USE_SIMDE
+    #ifdef __AVX2__
+    #include <simde/x86/avx2.h>
+    #else
+    #include <simde/x86/sse4.1.h> // SSE4.1 is covered better
+    #define __SSE4_1__
+    #endif
+
+    #elif defined(__AVX2__) || defined(__SSE4_1__)
     #include <immintrin.h> // AVX2 and lower
+    #endif
 }
 
 #include "spoa/graph.hpp"


### PR DESCRIPTION
SIMDe includes implementations of SIMD instruction sets for systems which don't natively support them. I have used this to port SSE4.1 to ARM NEON intrisics and there is a performance gain wrt auto-vectorized SISD-code version on ARM.