### PR TITLE
CPU dispatcher to different SIMD architectures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/simde"]
 	path = vendor/simde
 	url = https://github.com/nemequ/simde.git
+[submodule "vendor/FeatureDetector"]
+	path = vendor/FeatureDetector
+	url = https://github.com/Mysticial/FeatureDetector.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,7 @@
 [submodule "vendor/simde"]
 	path = vendor/simde
 	url = https://github.com/nemequ/simde.git
-[submodule "vendor/FeatureDetector"]
-	path = vendor/FeatureDetector
-	url = https://github.com/Mysticial/FeatureDetector.git
+[submodule "vendor/cpu_features"]
+	path = vendor/cpu_features
+	url = https://github.com/mbrcic/cpu_features.git
+	branch = patch-4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,13 @@ option(spoa_use_simde_nonvec "Use SIMDe library for nonvectorized code" OFF)
 option(spoa_use_simde_openmp "Use SIMDe support for OpenMP SIMD" OFF)
 option(spoa_generate_dispatch "Use SIMDe to generate x86 dispatch" OFF)
 
-if (spoa_optimize_for_portability)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
-elseif (spoa_optimize_for_native)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+
+if(NOT spoa_generate_dispatch) # optimization flags defeat the purpose of dispatching
+    if (spoa_optimize_for_portability)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
+    elseif (spoa_optimize_for_native)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    endif()
 endif()
 
 if (spoa_use_simde OR spoa_use_simde_nonvec OR spoa_use_simde_openmp OR spoa_generate_dispatch)
@@ -49,40 +52,35 @@ list(APPEND INCLUDES
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/simde>)
 
+# generating in also a dispatcher that handles both dispatching and non-dispatching case
+
 add_library(spoa
     src/alignment_engine.cpp
     src/graph.cpp
-    src/sisd_alignment_engine.cpp)
+    src/sisd_alignment_engine.cpp
+    src/dispatcher.cpp)
 
 target_include_directories(spoa PUBLIC
-    ${INCLUDES})
+    ${INCLUDES}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/FeatureDetector/src/x86>)
 
 set_target_properties(spoa
     PROPERTIES
     VERSION ${spoa_VERSION}
     SOVERSION ${spoa_VERSION})
 
-# generating dispatcher that handles both dispatching and non-dispatching case
+# in dispatching case, generate different optimized versions
+
+if (spoa_generate_dispatch)
 
 if (NOT TARGET FeatureDetector)
         add_subdirectory(vendor/FeatureDetector/src/x86 EXCLUDE_FROM_ALL)
 endif()
 
-add_library(spoa_dispatcher
-    src/dispatcher.cpp)
-
-target_include_directories(spoa_dispatcher PUBLIC
-    ${INCLUDES}
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/FeatureDetector/src/x86>)
-
-# in dispatching case, generate different optimized versions
-
-if (spoa_generate_dispatch)
-
 list(APPEND Archs avx2 sse4.1 sse2)
 
 foreach(arch IN LISTS Archs)
-add_library(spoa_${arch}
+add_library(spoa_${arch} OBJECT
     src/simd_alignment_engine_dispatch.cpp)
 target_include_directories(spoa_${arch} PUBLIC
     ${INCLUDES})
@@ -91,11 +89,13 @@ set_target_properties(spoa_${arch}
 
 endforeach()
 
-target_link_libraries(spoa_dispatcher FeatureDetector spoa_avx2 spoa_sse4.1 spoa_sse2 )
+target_link_libraries(spoa 
+    FeatureDetector 
+    $<TARGET_OBJECTS:spoa_avx2> 
+    $<TARGET_OBJECTS:spoa_sse4.1> 
+    $<TARGET_OBJECTS:spoa_sse2>)
 
 endif()
-
-target_link_libraries(spoa spoa_dispatcher)
 
 install(TARGETS spoa DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/spoa DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(spoa
 
 target_include_directories(spoa PUBLIC
     ${INCLUDES}
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/FeatureDetector/src/x86>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/cpu_features/include>)
 
 set_target_properties(spoa
     PROPERTIES
@@ -73,8 +73,8 @@ set_target_properties(spoa
 
 if (spoa_generate_dispatch)
 
-if (NOT TARGET FeatureDetector)
-        add_subdirectory(vendor/FeatureDetector/src/x86 EXCLUDE_FROM_ALL)
+if (NOT TARGET cpu_features)
+        add_subdirectory(vendor/cpu_features EXCLUDE_FROM_ALL)
 endif()
 
 list(APPEND Archs avx2 sse4.1 sse2)
@@ -90,7 +90,7 @@ set_target_properties(spoa_${arch}
 endforeach()
 
 target_link_libraries(spoa 
-    FeatureDetector 
+    cpu_features 
     $<TARGET_OBJECTS:spoa_avx2> 
     $<TARGET_OBJECTS:spoa_sse4.1> 
     $<TARGET_OBJECTS:spoa_sse2>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(spoa_optimize_for_portability "Build spoa with -msse4.1" OFF)
 option(spoa_use_simde "Use SIMDe library for porting vectorized code" OFF)
 option(spoa_use_simde_nonvec "Use SIMDe library for nonvectorized code" OFF)
 option(spoa_use_simde_openmp "Use SIMDe support for OpenMP SIMD" OFF)
+option(spoa_generate_dispatch "Use SIMDe to generate x86 dispatch" OFF)
 
 if (spoa_optimize_for_portability)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
@@ -26,7 +27,7 @@ elseif (spoa_optimize_for_native)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 endif()
 
-if (spoa_use_simde OR spoa_use_simde_nonvec OR spoa_use_simde_openmp)
+if (spoa_use_simde OR spoa_use_simde_nonvec OR spoa_use_simde_openmp OR spoa_generate_dispatch)
     add_definitions(-DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES)
     if (spoa_use_simde_nonvec)
         add_definitions(-DSIMDE_NO_NATIVE)
@@ -35,26 +36,66 @@ if (spoa_use_simde OR spoa_use_simde_nonvec OR spoa_use_simde_openmp)
         add_definitions(-DSIMDE_ENABLE_OPENMP)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp-simd")
     endif()
+    if (spoa_generate_dispatch)
+        add_definitions(-DGEN_DISPATCH)
+    endif()
 endif()
 
 # build SPOA as a static library by default
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build all libraries as shared")
 
-add_library(spoa
-    src/alignment_engine.cpp
-    src/graph.cpp
-    src/simd_alignment_engine.cpp
-    src/sisd_alignment_engine.cpp)
-
-target_include_directories(spoa PUBLIC
+list(APPEND INCLUDES 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/simde>)
+
+add_library(spoa
+    src/alignment_engine.cpp
+    src/graph.cpp
+    src/sisd_alignment_engine.cpp)
+
+target_include_directories(spoa PUBLIC
+    ${INCLUDES})
 
 set_target_properties(spoa
     PROPERTIES
     VERSION ${spoa_VERSION}
     SOVERSION ${spoa_VERSION})
+
+# generating dispatcher that handles both dispatching and non-dispatching case
+
+if (NOT TARGET FeatureDetector)
+        add_subdirectory(vendor/FeatureDetector/src/x86 EXCLUDE_FROM_ALL)
+endif()
+
+add_library(spoa_dispatcher
+    src/dispatcher.cpp)
+
+target_include_directories(spoa_dispatcher PUBLIC
+    ${INCLUDES}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/FeatureDetector/src/x86>)
+
+# in dispatching case, generate different optimized versions
+
+if (spoa_generate_dispatch)
+
+list(APPEND Archs avx2 sse4.1 sse2)
+
+foreach(arch IN LISTS Archs)
+add_library(spoa_${arch}
+    src/simd_alignment_engine_dispatch.cpp)
+target_include_directories(spoa_${arch} PUBLIC
+    ${INCLUDES})
+set_target_properties(spoa_${arch}
+    PROPERTIES COMPILE_FLAGS "-m${arch}")
+
+endforeach()
+
+target_link_libraries(spoa_dispatcher FeatureDetector spoa_avx2 spoa_sse4.1 spoa_sse2 )
+
+endif()
+
+target_link_libraries(spoa spoa_dispatcher)
 
 install(TARGETS spoa DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/spoa DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/include/spoa/architectures.hpp
+++ b/include/spoa/architectures.hpp
@@ -1,0 +1,10 @@
+/*!
+ * @file architectures.hpp
+ *
+ * @brief Arch enum class header file
+ */
+namespace spoa {
+
+enum class Arch{avx2, sse4_1, sse2, automatic};
+
+}

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -1,16 +1,17 @@
-#include <iostream>
+/*!
+ * @file dispatcher.cpp
+ *
+ * @brief CPU dispatching mechanism that also covers non-dispatching case
+ */
 
 #ifdef GEN_DISPATCH
 
-//#include "cpuinfo_x86.h"
+// FeatureDetector - can be substituted for google's cpu_features
 #include "cpu_x86.h"
 
 #endif
 #include "simd_alignment_engine_impl.hpp"
 
-//static const cpu_features::X86Features features = cpu_features::GetX86Info().features;
-
-//static const struct cpu_x86 features(cpu_x86.detect_host());
 
 namespace spoa{
 
@@ -27,25 +28,25 @@ std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine<Arch::automatic>(Alig
 std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
     AlignmentSubtype subtype, std::int8_t m, std::int8_t n, std::int8_t g,
     std::int8_t e, std::int8_t q, std::int8_t c) {
-        //std::cout<<features.sse4_1<<std::endl;
+
 #ifdef GEN_DISPATCH
         FeatureDetector::cpu_x86 cpu_features;
         cpu_features.detect_host();
 
     if (cpu_features.HW_AVX2)
     {
-        std::cout<<"AVX2"<<std::endl;
+        //std::cout<<"AVX2"<<std::endl;
         return createSimdAlignmentEngine<Arch::avx2>(type,
             subtype, m, n, g, e, q, c);
     }
     else if (cpu_features.HW_SSE41){
 
-        std::cout<<"SSE4"<<std::endl;
+        //std::cout<<"SSE4"<<std::endl;
         return createSimdAlignmentEngine<Arch::sse4_1>(type,
             subtype, m, n, g, e, q, c);
     }
     else {
-        std::cout<<"SSE2"<<std::endl;
+        //std::cout<<"SSE2"<<std::endl;
         return createSimdAlignmentEngine<Arch::sse2>(type,
             subtype, m, n, g, e, q, c);
     }

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -4,13 +4,15 @@
  * @brief CPU dispatching mechanism that also covers non-dispatching case
  */
 
+#include "simd_alignment_engine_impl.hpp"
+
 #ifdef GEN_DISPATCH
 
-// FeatureDetector - can be substituted for google's cpu_features
-#include "cpu_x86.h"
+#include "cpuinfo_x86.h"
+
+static const cpu_features::X86Features features = cpu_features::GetX86Info().features;
 
 #endif
-#include "simd_alignment_engine_impl.hpp"
 
 
 namespace spoa{
@@ -30,16 +32,14 @@ std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
     std::int8_t e, std::int8_t q, std::int8_t c) {
 
 #ifdef GEN_DISPATCH
-        FeatureDetector::cpu_x86 cpu_features;
-        cpu_features.detect_host();
 
-    if (cpu_features.HW_AVX2)
+    if (features.avx2)
     {
         //std::cout<<"AVX2"<<std::endl;
         return createSimdAlignmentEngine<Arch::avx2>(type,
             subtype, m, n, g, e, q, c);
     }
-    else if (cpu_features.HW_SSE41){
+    else if (features.sse4_1){
 
         //std::cout<<"SSE4"<<std::endl;
         return createSimdAlignmentEngine<Arch::sse4_1>(type,

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+
+#ifdef GEN_DISPATCH
+
+//#include "cpuinfo_x86.h"
+#include "cpu_x86.h"
+
+#endif
+#include "simd_alignment_engine_impl.hpp"
+
+//static const cpu_features::X86Features features = cpu_features::GetX86Info().features;
+
+//static const struct cpu_x86 features(cpu_x86.detect_host());
+
+namespace spoa{
+
+#ifndef GEN_DISPATCH
+template class SimdAlignmentEngine<Arch::automatic>;
+
+template
+std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine<Arch::automatic>(AlignmentType type,
+    AlignmentSubtype subtype, std::int8_t m, std::int8_t n, std::int8_t g,
+    std::int8_t e, std::int8_t q, std::int8_t c);
+#endif
+
+
+std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
+    AlignmentSubtype subtype, std::int8_t m, std::int8_t n, std::int8_t g,
+    std::int8_t e, std::int8_t q, std::int8_t c) {
+        //std::cout<<features.sse4_1<<std::endl;
+#ifdef GEN_DISPATCH
+        FeatureDetector::cpu_x86 cpu_features;
+        cpu_features.detect_host();
+
+    if (cpu_features.HW_AVX2)
+    {
+        std::cout<<"AVX2"<<std::endl;
+        return createSimdAlignmentEngine<Arch::avx2>(type,
+            subtype, m, n, g, e, q, c);
+    }
+    else if (cpu_features.HW_SSE41){
+
+        std::cout<<"SSE4"<<std::endl;
+        return createSimdAlignmentEngine<Arch::sse4_1>(type,
+            subtype, m, n, g, e, q, c);
+    }
+    else {
+        std::cout<<"SSE2"<<std::endl;
+        return createSimdAlignmentEngine<Arch::sse2>(type,
+            subtype, m, n, g, e, q, c);
+    }
+#else
+    return createSimdAlignmentEngine<Arch::automatic>(type,
+            subtype, m, n, g, e, q, c);
+#endif
+
+
+}
+
+}
+

--- a/src/simd_alignment_engine.hpp
+++ b/src/simd_alignment_engine.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file simd_alignment_engine.hpp
  *
- * @brief SimdAlignmentEngine class header file
+ * @brief SimdAlignmentEngine class template definition file
  */
 
 #pragma once

--- a/src/simd_alignment_engine.hpp
+++ b/src/simd_alignment_engine.hpp
@@ -12,16 +12,29 @@
 #include <vector>
 
 #include "spoa/alignment_engine.hpp"
+#include "spoa/architectures.hpp"
 
 namespace spoa {
 
 class Graph;
 
+template<Arch S> 
 class SimdAlignmentEngine;
+
 std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
     AlignmentSubtype subtype, std::int8_t m, std::int8_t n, std::int8_t g,
     std::int8_t e, std::int8_t q, std::int8_t c);
 
+
+
+template<Arch S>
+std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
+    AlignmentSubtype subtype, std::int8_t m, std::int8_t n, std::int8_t g,
+    std::int8_t e, std::int8_t q, std::int8_t c);
+
+
+
+template<Arch S> 
 class SimdAlignmentEngine: public AlignmentEngine {
 public:
     ~SimdAlignmentEngine();
@@ -32,7 +45,7 @@ public:
     Alignment align(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph) noexcept override;
 
-    friend std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(
+    friend std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine<S>(
         AlignmentType type, AlignmentSubtype subtype, std::int8_t m,
         std::int8_t n, std::int8_t g, std::int8_t e, std::int8_t q,
         std::int8_t c);

--- a/src/simd_alignment_engine_dispatch.cpp
+++ b/src/simd_alignment_engine_dispatch.cpp
@@ -1,4 +1,10 @@
-  #include "simd_alignment_engine_impl.hpp"
+/*!
+ * @file simd_alignment_engine_dispatch.cpp
+ *
+ * @brief Instantiation of different SIMD engines
+ */
+
+ #include "simd_alignment_engine_impl.hpp"
 
  #if defined(__AVX2__)
  #define ARCH Arch::avx2

--- a/src/simd_alignment_engine_dispatch.cpp
+++ b/src/simd_alignment_engine_dispatch.cpp
@@ -1,0 +1,22 @@
+  #include "simd_alignment_engine_impl.hpp"
+
+ #if defined(__AVX2__)
+ #define ARCH Arch::avx2
+ #elif defined (__SSE4_1__)
+ #define ARCH Arch::sse4_1
+ #else
+ #define ARCH Arch::sse2
+ #endif
+
+
+namespace spoa{
+
+template class SimdAlignmentEngine<ARCH>;
+
+template
+std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine<ARCH>(AlignmentType type,
+    AlignmentSubtype subtype, std::int8_t m, std::int8_t n, std::int8_t g,
+    std::int8_t e, std::int8_t q, std::int8_t c);
+
+}
+

--- a/src/simd_alignment_engine_impl.hpp
+++ b/src/simd_alignment_engine_impl.hpp
@@ -1,7 +1,7 @@
 /*!
- * @file simd_alignment_engine.cpp
+ * @file simd_alignment_engine_impl.hpp
  *
- * @brief SimdAlignmentEngine class source file
+ * @brief SimdAlignmentEngine class template implementation file
  */
 
 #include <iostream>


### PR DESCRIPTION
The code currently has only AVX2,SSE4.1 and SSE2 dispatching but other architectures are easy to add:

   1. you expand enumeration Arch with new architecture
   2. add dispatching case in dispatcher.cpp
   3. add new case at the beginning of simd_alignment_engine_dispatch.cpp
   4. add case with compiler flags to cmake configuration

It amounts to small amount of added code per new architecture.

I have used [FeatureDetector](https://github.com/Mysticial/FeatureDetector) for CPU dispatching since cpu_features has a [bug](https://github.com/google/cpu_features/issues/4) that needs to be resolved. In future, FeatureDetector should be be replaced with [cpu_features](https://github.com/google/cpu_features) in CPU dispatcher.

Also, the non-dispatching case works just as before.