### PR TITLE
write GFAv1 of POA graph

### DIFF
--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -83,6 +83,8 @@ public:
 
     void print_dot(const std::string& path) const;
 
+    void print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names) const;
+
     void clear();
 
     friend std::unique_ptr<Graph> createGraph();

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -83,7 +83,7 @@ public:
 
     void print_dot(const std::string& path) const;
 
-    void print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names) const;
+    void print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names, bool include_consensus = false) const;
 
     void clear();
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -726,6 +726,47 @@ void Graph::print_dot(const std::string& path) const {
     out.close();
 }
 
+void Graph::print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names) const {
+
+    std::vector<std::int32_t> in_consensus(nodes_.size(), -1);
+    std::int32_t rank = 0;
+    for (const auto& id: consensus_) {
+        in_consensus[id] = rank++;
+    }
+
+    out << "H" << "\t" << "VN:Z:1.0" << std::endl;
+
+    for (std::uint32_t i = 0; i < nodes_.size(); ++i) {
+        out << "S" << "\t" << i+1 << "\t" << static_cast<char>(decoder_[nodes_[i]->code_]);
+        if (in_consensus[i] != -1) {
+            out << "\t" << "ic:Z:true";
+        }
+        out << std::endl;
+        for (const auto& edge: nodes_[i]->out_edges_) {
+            out << "L" << "\t" << i+1 << "\t" << "+" << "\t" << edge->end_node_id_+1 << "\t" << "+" << "\t" << "0M" << "\t"
+                << "ew:f:" << edge->total_weight_;
+            if (in_consensus[i] + 1 == in_consensus[edge->end_node_id_]) {
+                out << "\t" << "ic:Z:true";
+            }
+            out << std::endl;
+        }
+    }
+
+    for (std::uint32_t i = 0; i < num_sequences_; ++i) {
+        out << "P" << "\t" << sequence_names[i] << "\t";
+        std::uint32_t node_id = sequences_begin_nodes_ids_[i];
+        while (true) {
+            out << node_id+1 << "+";
+            if (!nodes_[node_id]->successor(node_id, i)) {
+                break;
+            } else {
+                out << ",";
+            }
+        }
+        out << "\t" << "*" << std::endl;
+    }
+}
+
 void Graph::clear() {
     num_codes_ = 0;
     num_sequences_ = 0;

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -726,7 +726,9 @@ void Graph::print_dot(const std::string& path) const {
     out.close();
 }
 
-void Graph::print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names) const {
+void Graph::print_gfa(std::ostream& out,
+                      const std::vector<std::string>& sequence_names,
+                      bool include_consensus) const {
 
     std::vector<std::int32_t> in_consensus(nodes_.size(), -1);
     std::int32_t rank = 0;
@@ -762,6 +764,14 @@ void Graph::print_gfa(std::ostream& out, const std::vector<std::string>& sequenc
             } else {
                 out << ",";
             }
+        }
+        out << "\t" << "*" << std::endl;
+    }
+
+    if (include_consensus) {
+        out << "P" << "\t" << "Consensus" << "\t";
+        for (const auto& id: consensus_) {
+            out << id+1 << "+";
         }
         out << "\t" << "*" << std::endl;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,9 +36,10 @@ int main(int argc, char** argv) {
     std::uint8_t result = 0;
 
     std::string dot_path = "";
+    bool write_gfa = false;
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "m:n:g:e:q:c:l:r:d:h", options, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "m:n:g:e:q:c:l:r:d:fh", options, nullptr)) != -1) {
         switch (opt) {
             case 'm': m = atoi(optarg); break;
             case 'n': n = atoi(optarg); break;
@@ -49,6 +50,7 @@ int main(int argc, char** argv) {
             case 'l': algorithm = atoi(optarg); break;
             case 'r': result = atoi(optarg); break;
             case 'd': dot_path = optarg; break;
+            case 'f': write_gfa = true; break;
             case 'v': std::cout << version << std::endl; return 0;
             case 'h': help(); return 0;
             default: return 1;
@@ -118,7 +120,17 @@ int main(int argc, char** argv) {
         }
     }
 
-    if (result == 0) {
+    if (write_gfa) {
+        // force consensus genertion for graph annotation
+        std::string consensus = graph->generate_consensus();
+        // save sequence names for graph path labeling
+        std::vector<std::string> sequence_names;
+        for (auto& s : sequences) {
+            sequence_names.push_back(s->name());
+        }
+        // write the graph
+        graph->print_gfa(std::cout, sequence_names);
+    } else if (result == 0) {
         std::string consensus = graph->generate_consensus();
         std::cout << ">Consensus LN:i:" << consensus.size() << std::endl
                   << consensus << std::endl;
@@ -177,6 +189,8 @@ void help() {
         "                0 - consensus\n"
         "                1 - multiple sequence alignment\n"
         "                2 - 0 & 1\n"
+        "        -f, --gfa\n"
+        "            write GFA on stdout\n"
         "        -d, --dot <file>\n"
         "            output file for the final POA graph in DOT format\n"
         "        --version\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@ static struct option options[] = {
     {"algorithm", required_argument, nullptr, 'l'},
     {"result", required_argument, nullptr, 'r'},
     {"dot", required_argument, nullptr, 'd'},
+    {"gfa", required_argument, nullptr, 'd'},
     {"version", no_argument, nullptr, 'v'},
     {"help", no_argument, nullptr, 'h'},
     {nullptr, 0, nullptr, 0}
@@ -37,9 +38,10 @@ int main(int argc, char** argv) {
 
     std::string dot_path = "";
     bool write_gfa = false;
+    bool write_gfa_with_consensus = false;
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "m:n:g:e:q:c:l:r:d:fh", options, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "m:n:g:e:q:c:l:r:d:GCh", options, nullptr)) != -1) {
         switch (opt) {
             case 'm': m = atoi(optarg); break;
             case 'n': n = atoi(optarg); break;
@@ -50,7 +52,8 @@ int main(int argc, char** argv) {
             case 'l': algorithm = atoi(optarg); break;
             case 'r': result = atoi(optarg); break;
             case 'd': dot_path = optarg; break;
-            case 'f': write_gfa = true; break;
+            case 'G': write_gfa = true; break;
+            case 'C': write_gfa = true; write_gfa_with_consensus = true; break;
             case 'v': std::cout << version << std::endl; return 0;
             case 'h': help(); return 0;
             default: return 1;
@@ -128,8 +131,8 @@ int main(int argc, char** argv) {
         for (auto& s : sequences) {
             sequence_names.push_back(s->name());
         }
-        // write the graph
-        graph->print_gfa(std::cout, sequence_names);
+        // write the graph, with consensus as a path if requested
+        graph->print_gfa(std::cout, sequence_names, write_gfa_with_consensus);
     } else if (result == 0) {
         std::string consensus = graph->generate_consensus();
         std::cout << ">Consensus LN:i:" << consensus.size() << std::endl
@@ -189,8 +192,10 @@ void help() {
         "                0 - consensus\n"
         "                1 - multiple sequence alignment\n"
         "                2 - 0 & 1\n"
-        "        -f, --gfa\n"
+        "        -G, --gfa\n"
         "            write GFA on stdout\n"
+        "        -C, --gfa-with-consensus\n"
+        "            write GFA with consensus on stdout\n"
         "        -d, --dot <file>\n"
         "            output file for the final POA graph in DOT format\n"
         "        --version\n"


### PR DESCRIPTION
This PR adds a function on the Graph object that writes the POA in GFAv1 format.

This graph can be normalized and processed with external tools like odgi:

```
spoa -f sample.fastq >sample.gfa
odgi build -g sample.gfa -o - \
    | odgi unchop -i - -o - \
    | odgi sort -i - -o sample.odgi
```

The graph appears to have the expected linear structure:

```
odgi layout -i - -o x.svg -e 0.1 -p 100
```

![Screenshot from 2020-05-31 11-21-48](https://user-images.githubusercontent.com/145425/83348948-fe64d480-a330-11ea-8816-2e6d25842b6f.png)

And we can see that the included sequences map across it as expected:

```
odgi viz -i sample.odgi -o x.png -x 4000 -y 500 -R
```

![x](https://user-images.githubusercontent.com/145425/83348954-058be280-a331-11ea-874d-127040630315.png)

It might be nice to optionally include the consensus as an embedded path in the resulting graph. How else can we improve this?