### PR TITLE
Fix compiler error while generating shared library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,26 +74,26 @@ set_target_properties(spoa
 if (spoa_generate_dispatch)
 
 if (NOT TARGET cpu_features)
-        add_subdirectory(vendor/cpu_features EXCLUDE_FROM_ALL)
+    add_subdirectory(vendor/cpu_features)
 endif()
 
 list(APPEND Archs avx2 sse4.1 sse2)
 
 foreach(arch IN LISTS Archs)
-add_library(spoa_${arch} OBJECT
-    src/simd_alignment_engine_dispatch.cpp)
-target_include_directories(spoa_${arch} PUBLIC
-    ${INCLUDES})
-set_target_properties(spoa_${arch}
-    PROPERTIES COMPILE_FLAGS "-m${arch}")
-
+add_library(spoa_${arch} OBJECT src/simd_alignment_engine_dispatch.cpp)
+target_include_directories(spoa_${arch} PUBLIC ${INCLUDES})
+set_target_properties(spoa_${arch} PROPERTIES COMPILE_FLAGS "-m${arch}")
+if (BUILD_SHARED_LIBS)
+set_property(TARGET spoa_${arch}
+    PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 endforeach()
 
 target_link_libraries(spoa
     cpu_features
-    $<TARGET_OBJECTS:spoa_avx2>
-    $<TARGET_OBJECTS:spoa_sse4.1>
-    $<TARGET_OBJECTS:spoa_sse2>)
+    spoa_avx2
+    spoa_sse4.1
+    spoa_sse2)
 
 endif()
 


### PR DESCRIPTION
1. Shared library object now uses position independent code.
2. `make install` now installs `cpu_features` library along with `spoa` library.

Test Plan:
```
# Generate Shared Library
cmake /path/to/spoa -DBUILD_SHARED_LIBS=ON -Dspoa_generate_dispatch=ON
make all
sudo make install  # Verfied that libspoa.so and libcpu_features.so are installed in /usr/local/lib/

# Generate Static Library
cmake /path/to/spoa -DBUILD_SHARED_LIBS=OFF -Dspoa_generate_dispatch=ON
make all
sudo make install # Verified that libspoa.a and libcpu_features.a are installed in /usrl/local/lib/
```