### PR TITLE
write GFA paths in reverse when alignment is reversed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Compiled Object files
 build/
+# emacs temp files
+*~

--- a/include/spoa/alignment_engine.hpp
+++ b/include/spoa/alignment_engine.hpp
@@ -49,11 +49,11 @@ public:
 
     Alignment align(const std::string& sequence,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score = nullptr);
+        std::int32_t* score = nullptr);
 
     virtual Alignment align(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score = nullptr) noexcept = 0;
+        std::int32_t* score = nullptr) noexcept = 0;
 
 protected:
     AlignmentEngine(AlignmentType type, AlignmentSubtype subtype, std::int8_t m,

--- a/include/spoa/alignment_engine.hpp
+++ b/include/spoa/alignment_engine.hpp
@@ -48,10 +48,12 @@ public:
         std::uint32_t alphabet_size) = 0;
 
     Alignment align(const std::string& sequence,
-        const std::unique_ptr<Graph>& graph);
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score = nullptr);
 
     virtual Alignment align(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept = 0;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score = nullptr) noexcept = 0;
 
 protected:
     AlignmentEngine(AlignmentType type, AlignmentSubtype subtype, std::int8_t m,

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -192,6 +192,10 @@ public:
         return end_node_id_;
     }
 
+    std::int64_t total_weight() const {
+        return total_weight_;\
+    }
+
     friend Graph;
     friend Node;
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -95,7 +95,7 @@ public:
 
     void print_dot(const std::string& path) const;
 
-    void print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names, bool include_consensus = false) const;
+    void print_gfa(std::ostream& out, const std::vector<std::string>& sequence_names, bool include_consensus = false, const std::vector<bool>& is_rev = {}) const;
 
     void clear();
 

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -47,6 +47,10 @@ public:
         return num_codes_;
     };
 
+    std::uint32_t num_sequences() const {
+        return num_codes_;
+    };
+
     std::uint8_t coder(std::uint8_t c) const {
         return coder_[c];
     }

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -35,6 +35,10 @@ public:
         return rank_to_node_id_;
     }
 
+    const std::vector<std::uint32_t>& consensus() const {
+        return consensus_;
+    }
+
     std::uint32_t num_codes() const {
         return num_codes_;
     };

--- a/include/spoa/graph.hpp
+++ b/include/spoa/graph.hpp
@@ -39,6 +39,10 @@ public:
         return consensus_;
     }
 
+    const std::vector<std::uint32_t>& sequences_begin_nodes_ids() const {
+        return sequences_begin_nodes_ids_;
+    }
+
     std::uint32_t num_codes() const {
         return num_codes_;
     };
@@ -195,7 +199,6 @@ public:
     std::int64_t total_weight() const {
         return total_weight_;\
     }
-
     friend Graph;
     friend Node;
 

--- a/src/alignment_engine.cpp
+++ b/src/alignment_engine.cpp
@@ -76,7 +76,7 @@ AlignmentEngine::AlignmentEngine(AlignmentType type, AlignmentSubtype subtype,
 
 Alignment AlignmentEngine::align(const std::string& sequence,
     const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) {
+    std::int32_t* score) {
 
     return align(sequence.c_str(), sequence.size(), graph, score);
 }

--- a/src/alignment_engine.cpp
+++ b/src/alignment_engine.cpp
@@ -75,9 +75,10 @@ AlignmentEngine::AlignmentEngine(AlignmentType type, AlignmentSubtype subtype,
 }
 
 Alignment AlignmentEngine::align(const std::string& sequence,
-    const std::unique_ptr<Graph>& graph) {
+    const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) {
 
-    return align(sequence.c_str(), sequence.size(), graph);
+    return align(sequence.c_str(), sequence.size(), graph, score);
 }
 
 }

--- a/src/dna.hpp
+++ b/src/dna.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <string>
+
+namespace dna {
+
+static const char complement[256] = {'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 8
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 16
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 24
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 32
+                                     'N', 'N', 'N', '$', '#', 'N', 'N', 'N', // 40 GCSA stop/start characters
+                                     'N', 'N', 'N', 'N', 'N', '-', 'N', 'N', // 48
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 56
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 64
+                                     'N', 'T', 'V', 'G', 'H', 'N', 'N', 'C', // 72
+                                     'D', 'N', 'N', 'M', 'N', 'K', 'N', 'N', // 80
+                                     'N', 'Q', 'Y', 'W', 'A', 'A', 'B', 'S', // 88
+                                     'N', 'R', 'N', 'N', 'N', 'N', 'N', 'N', // 96
+                                     'N', 't', 'v', 'g', 'h', 'N', 'N', 'c', // 104
+                                     'd', 'N', 'N', 'm', 'N', 'k', 'n', 'N', // 112
+                                     'N', 'q', 'y', 'w', 'a', 'a', 'b', 's', // 120
+                                     'N', 'r', 'N', 'N', 'N', 'N', 'N', 'N', // 128
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 136
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 144
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 152
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 160
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 168
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 176
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 184
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 192
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 200
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 208
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 216
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 224
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 232
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 240
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 248
+                                     'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N'};// 256
+
+inline char reverse_complement(const char& c) {
+    return complement[(size_t)c];
+}
+
+inline std::string reverse_complement(const std::string& seq) {
+    std::string rc;
+    rc.assign(seq.rbegin(), seq.rend());
+    for (auto& c : rc) {
+        c = complement[(size_t)c];
+    }
+    return rc;
+}
+    
+inline void reverse_complement_in_place(std::string& seq) {
+    size_t swap_size = seq.size() / 2;
+    for (size_t i = 0, j = seq.size() - 1; i < swap_size; i++, j--) {
+        char tmp = seq[i];
+        seq[i] = complement[(size_t)seq[j]];
+        seq[j] = complement[(size_t)tmp];
+    }
+    
+    if (seq.size() % 2) {
+        seq[swap_size] = complement[(size_t)seq[swap_size]];
+    }
+}
+
+inline void reverse_complement_in_place(char* seq, size_t len) {
+    size_t swap_size = len / 2;
+    for (size_t i = 0, j = len - 1; i < swap_size; i++, j--) {
+        char tmp = seq[i];
+        seq[i] = complement[(size_t)seq[j]];
+        seq[j] = complement[(size_t)tmp];
+    }
+    if (len % 2) {
+        seq[swap_size] = complement[(size_t)seq[swap_size]];
+    }
+}
+
+inline int dna_as_int(char c) {
+    switch (c) {
+    case 'A':
+        return 1;
+    case 'T':
+        return 2;
+    case 'C':
+        return 3;
+    case 'G':
+        return 4;
+    default:
+        return 5;
+    }
+}
+
+inline char int_as_dna(int i) {
+    switch (i) {
+    case 1:
+        return 'A';
+    case 2:
+        return 'T';
+    case 3:
+        return 'C';
+    case 4:
+        return 'G';
+    default:
+        return 'N';
+    }
+}
+
+}

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -728,7 +728,8 @@ void Graph::print_dot(const std::string& path) const {
 
 void Graph::print_gfa(std::ostream& out,
                       const std::vector<std::string>& sequence_names,
-                      bool include_consensus) const {
+                      bool include_consensus,
+                      const std::vector<bool>& is_rev) const {
 
     std::vector<std::int32_t> in_consensus(nodes_.size(), -1);
     std::int32_t rank = 0;
@@ -756,14 +757,20 @@ void Graph::print_gfa(std::ostream& out,
 
     for (std::uint32_t i = 0; i < num_sequences_; ++i) {
         out << "P" << "\t" << sequence_names[i] << "\t";
+        std::vector<uint32_t> ids;
         std::uint32_t node_id = sequences_begin_nodes_ids_[i];
         while (true) {
-            out << node_id+1 << "+";
+            ids.push_back(node_id+1);
             if (!nodes_[node_id]->successor(node_id, i)) {
                 break;
-            } else {
-                out << ",";
             }
+        }
+        bool rev_path = !is_rev.empty() && is_rev[i];
+        if (rev_path) {
+            std::reverse(ids.begin(), ids.end());
+        }
+        for (std::uint32_t j = 0; j < ids.size(); ++j) {
+            out << ids[j] << (rev_path ? "-" : "+") << (j < ids.size()-1 ? "," : "");
         }
         out << "\t" << "*" << std::endl;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,7 @@ int main(int argc, char** argv) {
     }
     alignment_engine->prealloc(max_sequence_size, 4);
 
+    std::vector<bool> is_rev;
     if (try_reverse_complement) {
         for (const auto& it: sequences) {
             std::int32_t score_fwd = 0;
@@ -129,8 +130,10 @@ int main(int argc, char** argv) {
             try {
                 if (score_fwd >= score_rev) {
                     graph->add_alignment(alignment_fwd, it->data(), it->quality());
+                    is_rev.push_back(false);
                 } else {
                     graph->add_alignment(alignment_rev, reversed.data(), reversed.quality());
+                    is_rev.push_back(true);
                 }
             } catch(std::invalid_argument& exception) {
                 std::cerr << exception.what() << std::endl;
@@ -158,7 +161,7 @@ int main(int argc, char** argv) {
             sequence_names.push_back(s->name());
         }
         // write the graph, with consensus as a path if requested
-        graph->print_gfa(std::cout, sequence_names, write_gfa_with_consensus);
+        graph->print_gfa(std::cout, sequence_names, write_gfa_with_consensus, is_rev);
     } else if (result == 0) {
         std::string consensus = graph->generate_consensus();
         std::cout << ">Consensus LN:i:" << consensus.size() << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,10 +114,8 @@ int main(int argc, char** argv) {
     }
     alignment_engine->prealloc(max_sequence_size, 4);
 
-    std::uint32_t score = 0;
     for (const auto& it: sequences) {
-        auto alignment = alignment_engine->align(it->data(), graph, &score);
-        std::cerr << score << std::endl;
+        auto alignment = alignment_engine->align(it->data(), graph);
         try {
             graph->add_alignment(alignment, it->data(), it->quality());
         } catch(std::invalid_argument& exception) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,8 +114,10 @@ int main(int argc, char** argv) {
     }
     alignment_engine->prealloc(max_sequence_size, 4);
 
+    std::uint32_t score = 0;
     for (const auto& it: sequences) {
-        auto alignment = alignment_engine->align(it->data(), graph);
+        auto alignment = alignment_engine->align(it->data(), graph, &score);
+        std::cerr << score << std::endl;
         try {
             graph->add_alignment(alignment, it->data(), it->quality());
         } catch(std::invalid_argument& exception) {

--- a/src/sequence.hpp
+++ b/src/sequence.hpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <algorithm>
+#include "dna.hpp"
 
 namespace bioparser {
     template<class T>
@@ -37,6 +39,11 @@ public:
         return quality_;
     }
 
+    void reverse_complement() {
+        dna::reverse_complement_in_place(data_);
+        std::reverse(quality_.begin(), quality_.end());
+    }
+
     friend bioparser::FastaParser<Sequence>;
     friend bioparser::FastqParser<Sequence>;
 
@@ -46,8 +53,8 @@ private:
     Sequence(const char* name, std::uint32_t name_size,
         const char* data, std::uint32_t data_size,
         const char* quality, std::uint32_t quality_size);
-    Sequence(const Sequence&) = delete;
-    const Sequence& operator=(const Sequence&) = delete;
+    //Sequence(const Sequence&) = delete;
+    //const Sequence& operator=(const Sequence&) = delete;
 
     std::string name_;
     std::string data_;

--- a/src/simd_alignment_engine.hpp
+++ b/src/simd_alignment_engine.hpp
@@ -44,7 +44,7 @@ public:
 
     Alignment align(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept override;
+        std::int32_t* score) noexcept override;
 
     friend std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine<S>(
         AlignmentType type, AlignmentSubtype subtype, std::int8_t m,
@@ -61,17 +61,17 @@ private:
     template<typename T>
     Alignment linear(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept;
+        std::int32_t* score) noexcept;
 
     template<typename T>
     Alignment affine(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept;
+        std::int32_t* score) noexcept;
 
     template<typename T>
     Alignment convex(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept;
+        std::int32_t* score) noexcept;
 
     void realloc(std::uint32_t matrix_width, std::uint32_t matrix_height,
         std::uint32_t num_codes);

--- a/src/simd_alignment_engine.hpp
+++ b/src/simd_alignment_engine.hpp
@@ -18,7 +18,7 @@ namespace spoa {
 
 class Graph;
 
-template<Arch S> 
+template<Arch S>
 class SimdAlignmentEngine;
 
 std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
@@ -34,7 +34,7 @@ std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine(AlignmentType type,
 
 
 
-template<Arch S> 
+template<Arch S>
 class SimdAlignmentEngine: public AlignmentEngine {
 public:
     ~SimdAlignmentEngine();
@@ -43,7 +43,8 @@ public:
         std::uint32_t alphabet_size) override;
 
     Alignment align(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept override;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept override;
 
     friend std::unique_ptr<AlignmentEngine> createSimdAlignmentEngine<S>(
         AlignmentType type, AlignmentSubtype subtype, std::int8_t m,
@@ -59,15 +60,18 @@ private:
 
     template<typename T>
     Alignment linear(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept;
 
     template<typename T>
     Alignment affine(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept;
 
     template<typename T>
     Alignment convex(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept;
 
     void realloc(std::uint32_t matrix_width, std::uint32_t matrix_height,
         std::uint32_t num_codes);

--- a/src/simd_alignment_engine_impl.hpp
+++ b/src/simd_alignment_engine_impl.hpp
@@ -668,7 +668,7 @@ void SimdAlignmentEngine<S>::initialize(const char* sequence,
 template<Arch S>
 Alignment SimdAlignmentEngine<S>::align(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
     if (graph->nodes().empty() || sequence_size == 0) {
         return Alignment();
@@ -712,7 +712,7 @@ template<Arch S>
 template<typename T>
 Alignment SimdAlignmentEngine<S>::linear(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
 #if defined(__AVX2__) || defined(__SSE4_1__) || defined(USE_SIMDE)
 
@@ -1065,7 +1065,7 @@ template<Arch S>
 template<typename T>
 Alignment SimdAlignmentEngine<S>::affine(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
 #if defined(__AVX2__) || defined(__SSE4_1__) || defined(USE_SIMDE)
 
@@ -1501,7 +1501,7 @@ template<Arch S>
 template<typename T>
 Alignment SimdAlignmentEngine<S>::convex(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
 #if defined(__AVX2__) || defined(__SSE4_1__) || defined(USE_SIMDE)
 

--- a/src/simd_alignment_engine_impl.hpp
+++ b/src/simd_alignment_engine_impl.hpp
@@ -667,7 +667,8 @@ void SimdAlignmentEngine<S>::initialize(const char* sequence,
 
 template<Arch S>
 Alignment SimdAlignmentEngine<S>::align(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
     if (graph->nodes().empty() || sequence_size == 0) {
         return Alignment();
@@ -682,19 +683,19 @@ Alignment SimdAlignmentEngine<S>::align(const char* sequence,
 
     if (max_penalty * longest_path < std::numeric_limits<std::int16_t>::max()) {
         if (subtype_ == AlignmentSubtype::kLinear) {
-            return linear<InstructionSet<S,std::int16_t>>(sequence, sequence_size, graph);
+            return linear<InstructionSet<S,std::int16_t>>(sequence, sequence_size, graph, score);
         } else if (subtype_ == AlignmentSubtype::kAffine) {
-            return affine<InstructionSet<S,std::int16_t>>(sequence, sequence_size, graph);
+            return affine<InstructionSet<S,std::int16_t>>(sequence, sequence_size, graph, score);
         } else if (subtype_ == AlignmentSubtype::kConvex) {
-            return convex<InstructionSet<S,std::int16_t>>(sequence, sequence_size, graph);
+            return convex<InstructionSet<S,std::int16_t>>(sequence, sequence_size, graph, score);
         }
     } else {
         if (subtype_ == AlignmentSubtype::kLinear) {
-            return linear<InstructionSet<S,std::int32_t>>(sequence, sequence_size, graph);
+            return linear<InstructionSet<S,std::int32_t>>(sequence, sequence_size, graph, score);
         } else if (subtype_ == AlignmentSubtype::kAffine) {
-            return affine<InstructionSet<S,std::int32_t>>(sequence, sequence_size, graph);
+            return affine<InstructionSet<S,std::int32_t>>(sequence, sequence_size, graph, score);
         } else if (subtype_ == AlignmentSubtype::kConvex) {
-            return convex<InstructionSet<S,std::int32_t>>(sequence, sequence_size, graph);
+            return convex<InstructionSet<S,std::int32_t>>(sequence, sequence_size, graph, score);
         }
     }
 
@@ -710,7 +711,8 @@ Alignment SimdAlignmentEngine<S>::align(const char* sequence,
 template<Arch S>
 template<typename T>
 Alignment SimdAlignmentEngine<S>::linear(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
 #if defined(__AVX2__) || defined(__SSE4_1__) || defined(USE_SIMDE)
 
@@ -1045,6 +1047,10 @@ Alignment SimdAlignmentEngine<S>::linear(const char* sequence,
         }
     }
 
+    if (score != nullptr) {
+      *score = max_score;
+    }
+
     std::reverse(alignment.begin(), alignment.end());
     return alignment;
 
@@ -1058,7 +1064,8 @@ Alignment SimdAlignmentEngine<S>::linear(const char* sequence,
 template<Arch S>
 template<typename T>
 Alignment SimdAlignmentEngine<S>::affine(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
 #if defined(__AVX2__) || defined(__SSE4_1__) || defined(USE_SIMDE)
 
@@ -1476,6 +1483,10 @@ Alignment SimdAlignmentEngine<S>::affine(const char* sequence,
         }
     }
 
+    if (score != nullptr) {
+      *score = max_score;
+    }
+
     std::reverse(alignment.begin(), alignment.end());
     return alignment;
 
@@ -1489,7 +1500,8 @@ Alignment SimdAlignmentEngine<S>::affine(const char* sequence,
 template<Arch S>
 template<typename T>
 Alignment SimdAlignmentEngine<S>::convex(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
 #if defined(__AVX2__) || defined(__SSE4_1__) || defined(USE_SIMDE)
 
@@ -1981,6 +1993,10 @@ Alignment SimdAlignmentEngine<S>::convex(const char* sequence,
                 }
             }
         }
+    }
+
+    if (score != nullptr) {
+      *score = max_score;
     }
 
     std::reverse(alignment.begin(), alignment.end());

--- a/src/sisd_alignment_engine.cpp
+++ b/src/sisd_alignment_engine.cpp
@@ -241,24 +241,26 @@ void SisdAlignmentEngine::initialize(const char* sequence,
 }
 
 Alignment SisdAlignmentEngine::align(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
     if (graph->nodes().empty() || sequence_size == 0) {
         return Alignment();
     }
 
     if (subtype_ == AlignmentSubtype::kLinear) {
-        return linear(sequence, sequence_size, graph);
+        return linear(sequence, sequence_size, graph, score);
     } else if (subtype_ == AlignmentSubtype::kAffine) {
-        return affine(sequence, sequence_size, graph);
+        return affine(sequence, sequence_size, graph, score);
     } else if (subtype_ == AlignmentSubtype::kConvex) {
-        return convex(sequence, sequence_size, graph);
+        return convex(sequence, sequence_size, graph, score);
     }
     return Alignment();
 }
 
 Alignment SisdAlignmentEngine::linear(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
     std::uint32_t matrix_width = sequence_size + 1;
     std::uint32_t matrix_height = graph->nodes().size() + 1;
@@ -430,12 +432,17 @@ Alignment SisdAlignmentEngine::linear(const char* sequence,
         j = prev_j;
     }
 
+    if (score != nullptr) {
+      *score = max_score;
+    }
+
     std::reverse(alignment.begin(), alignment.end());
     return alignment;
 }
 
 Alignment SisdAlignmentEngine::affine(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
     std::uint32_t matrix_width = sequence_size + 1;
     std::uint32_t matrix_height = graph->nodes().size() + 1;
@@ -652,12 +659,17 @@ Alignment SisdAlignmentEngine::affine(const char* sequence,
         }
     }
 
+    if (score != nullptr) {
+      *score = max_score;
+    }
+
     std::reverse(alignment.begin(), alignment.end());
     return alignment;
 }
 
 Alignment SisdAlignmentEngine::convex(const char* sequence,
-    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph) noexcept {
+    std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
+    std::uint32_t* score) noexcept {
 
     std::uint32_t matrix_width = sequence_size + 1;
     std::uint32_t matrix_height = graph->nodes().size() + 1;
@@ -903,6 +915,10 @@ Alignment SisdAlignmentEngine::convex(const char* sequence,
                 }
             }
         }
+    }
+
+    if (score != nullptr) {
+      *score = max_score;
     }
 
     std::reverse(alignment.begin(), alignment.end());

--- a/src/sisd_alignment_engine.cpp
+++ b/src/sisd_alignment_engine.cpp
@@ -242,7 +242,7 @@ void SisdAlignmentEngine::initialize(const char* sequence,
 
 Alignment SisdAlignmentEngine::align(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
     if (graph->nodes().empty() || sequence_size == 0) {
         return Alignment();
@@ -260,7 +260,7 @@ Alignment SisdAlignmentEngine::align(const char* sequence,
 
 Alignment SisdAlignmentEngine::linear(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
     std::uint32_t matrix_width = sequence_size + 1;
     std::uint32_t matrix_height = graph->nodes().size() + 1;
@@ -442,7 +442,7 @@ Alignment SisdAlignmentEngine::linear(const char* sequence,
 
 Alignment SisdAlignmentEngine::affine(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
     std::uint32_t matrix_width = sequence_size + 1;
     std::uint32_t matrix_height = graph->nodes().size() + 1;
@@ -669,7 +669,7 @@ Alignment SisdAlignmentEngine::affine(const char* sequence,
 
 Alignment SisdAlignmentEngine::convex(const char* sequence,
     std::uint32_t sequence_size, const std::unique_ptr<Graph>& graph,
-    std::uint32_t* score) noexcept {
+    std::int32_t* score) noexcept {
 
     std::uint32_t matrix_width = sequence_size + 1;
     std::uint32_t matrix_height = graph->nodes().size() + 1;

--- a/src/sisd_alignment_engine.hpp
+++ b/src/sisd_alignment_engine.hpp
@@ -31,7 +31,7 @@ public:
 
     Alignment align(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept override;
+        std::int32_t* score) noexcept override;
 
     friend std::unique_ptr<AlignmentEngine> createSisdAlignmentEngine(
         AlignmentType type, AlignmentSubtype subtype, std::int8_t m,
@@ -47,15 +47,15 @@ private:
 
     Alignment linear(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept;
+        std::int32_t* score) noexcept;
 
     Alignment affine(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept;
+        std::int32_t* score) noexcept;
 
     Alignment convex(const char* sequence, std::uint32_t sequence_size,
         const std::unique_ptr<Graph>& graph,
-        std::uint32_t* score) noexcept;
+        std::int32_t* score) noexcept;
 
     void realloc(std::uint32_t matrix_width, std::uint32_t matrix_height,
         std::uint32_t num_codes);

--- a/src/sisd_alignment_engine.hpp
+++ b/src/sisd_alignment_engine.hpp
@@ -30,7 +30,8 @@ public:
         std::uint32_t alphabet_size) override;
 
     Alignment align(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept override;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept override;
 
     friend std::unique_ptr<AlignmentEngine> createSisdAlignmentEngine(
         AlignmentType type, AlignmentSubtype subtype, std::int8_t m,
@@ -45,13 +46,16 @@ private:
     const SisdAlignmentEngine& operator=(const SisdAlignmentEngine&) = delete;
 
     Alignment linear(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept;
 
     Alignment affine(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept;
 
     Alignment convex(const char* sequence, std::uint32_t sequence_size,
-        const std::unique_ptr<Graph>& graph) noexcept;
+        const std::unique_ptr<Graph>& graph,
+        std::uint32_t* score) noexcept;
 
     void realloc(std::uint32_t matrix_width, std::uint32_t matrix_height,
         std::uint32_t num_codes);


### PR DESCRIPTION
This adds another feature to the spoa executable, so that when a GFA output is selected and the alignment is reversed, we get the path embedded in the correct orientation.