### PR TITLE
Add cereal include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/spoa.pc.in
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spoa-1.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+include_directories(${PROJECT_SOURCE_DIR}/vendor/cereal/include/)
+
 option(spoa_build_executable "Build spoa standalone tool" OFF)
 if (spoa_build_executable)
   if (NOT TARGET biosoup)


### PR DESCRIPTION
I tried making the project with:

    mkdir build && cd build && cmake -D spoa_optimize_for_portability=ON -DCMAKE_BUILD_TYPE=Release -D CMAKE_CXX_FLAGS="-fPIC" .. && make

but hit:

    spoa/graph.hpp:14:29: fatal error: cereal/access.hpp: No such file or directory
