### PR TITLE
Fix for Convex SIMD traceback logic

### DIFF
--- a/src/simd_alignment_engine_implementation.hpp
+++ b/src/simd_alignment_engine_implementation.hpp
@@ -1961,10 +1961,10 @@ Alignment SimdAlignmentEngine<A>::Convex(
         j_div = j / T::kNumVar;
         j_mod = j % T::kNumVar;
         if ((j == -1) ||
-            (j_mod != T::kNumVar - 1 &&      E[j_mod] + e_ != E[j_mod + 1]) ||
-            (j_mod == T::kNumVar - 1 && E_left[j_mod] + e_ != E[0])         ||
-            (j_mod != T::kNumVar - 1 &&      Q[j_mod] + c_ != Q[j_mod + 1]) ||
-            (j_mod == T::kNumVar - 1 && Q_left[j_mod] + c_ != Q[0])) {
+            (((j_mod != T::kNumVar - 1 &&      E[j_mod] + e_ != E[j_mod + 1]) ||
+             (j_mod == T::kNumVar - 1 && E_left[j_mod] + e_ != E[0]))         &&
+             ((j_mod != T::kNumVar - 1 &&      Q[j_mod] + c_ != Q[j_mod + 1]) ||
+             (j_mod == T::kNumVar - 1 && Q_left[j_mod] + c_ != Q[0])))) {
           break;
         }
       }


### PR DESCRIPTION
In the SIMD traceback logic, the `extend_left` logic exits when the gap extension stops in  _either_ the E matrix _or_ the Q matrix.  This is incorrect, since we should only expect to be tracing back one type of gap or the other.  The correct exit condition is when the gap extension stops in _both_  the E matrix _and_ the Q matrix. [Compare to the same logic in the SISD implementation.](https://github.com/rvaser/spoa/blob/73f7a259b3598d629e883f8b6cf64288c84c695d/src/sisd_alignment_engine.cpp#L883C9-L886C10)

Fixes #75 
